### PR TITLE
add Opencv link for BaseLib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(Glog 0.3.4 REQUIRED)
 
 # OpenCV
 find_package(OpenCV REQUIRED)
+include_directories(${OPENCV_INCLUDE_DIRS})
 
 # PCL
 find_package(PCL 1.7 REQUIRED)
@@ -115,6 +116,8 @@ add_library(BaseLib
   src/opt/util.cc
   src/opt/visibility_estimator.cc
 )
+target_link_libraries(BaseLib
+  ${OpenCV_LIBS})
 set(BASE_LIB_LIBRARIES
   BaseLib
   ${OpenCV_LIBS}

--- a/src/dataset_inspector/gui_main_window.cc
+++ b/src/dataset_inspector/gui_main_window.cc
@@ -944,11 +944,11 @@ void MainWindow::TransferLabels(
   const int fill_in_threshold_int =
       static_cast<int>((kFillInThreshold * window_pixel_count) + 0.5f);
   
-  cv::Mat_<std::size_t> eval_obs_integral_image(target_mask.rows, target_mask.cols);
-  cv::Mat_<std::size_t> obs_integral_image(target_mask.rows, target_mask.cols);
+  cv::Mat_<int> eval_obs_integral_image(target_mask.rows, target_mask.cols);
+  cv::Mat_<int> obs_integral_image(target_mask.rows, target_mask.cols);
   // Set first row.
-  std::size_t eval_obs_row_sum = 0;
-  std::size_t obs_row_sum = 0;
+  int eval_obs_row_sum = 0;
+  int obs_row_sum = 0;
   for (int x = 0; x < target_mask.cols; ++ x) {
     if (transfer_eval_obs) {
       eval_obs_row_sum += ((target_mask(0, x) == opt::MaskType::kEvalObs) ? 1 : 0);

--- a/src/opt/image.cc
+++ b/src/opt/image.cc
@@ -45,7 +45,7 @@ void Image::LoadImageData(int image_scale_count, opt::Intrinsics* intrinsics, co
       file_path :
       (boost::filesystem::path(base_path) / file_path).string();
   image_.resize(image_scale_count);
-  image_[0] = cv::imread(image_file_path, CV_LOAD_IMAGE_GRAYSCALE);
+  image_[0] = cv::imread(image_file_path, cv::IMREAD_GRAYSCALE);
   if (image_[0].empty()) {
     LOG(FATAL) << "Cannot read image: " << file_path;
   }
@@ -115,7 +115,7 @@ void Image::BuildImagePyramid() {
     cv::resize(image_.at(i - 1), image_.at(i),
                 cv::Size(scale_factor * image_.at(i - 1).cols,
                          scale_factor * image_.at(i - 1).rows),
-                scale_factor, scale_factor, CV_INTER_AREA);
+                scale_factor, scale_factor, cv::INTER_AREA);
     if (image_.at(i).empty()) {
       LOG(FATAL) << "Resizing failed";
     }

--- a/src/opt/problem.cc
+++ b/src/opt/problem.cc
@@ -650,7 +650,7 @@ void Problem::DebugWriteColoredPointCloud(const pcl::PointCloud<pcl::PointXYZ>::
     visibility_estimator.AppendObservationsForImageNoScale(
         occlusion_geometry(), *point_cloud, image, intrinsics, 0, &observations);
     
-    cv::Mat_<cv::Vec3b> color_image = cv::imread(image.file_path, CV_LOAD_IMAGE_COLOR);
+    cv::Mat_<cv::Vec3b> color_image = cv::imread(image.file_path, cv::IMREAD_COLOR);
     if (color_image.empty()) {
       LOG(FATAL) << "Cannot read image: " << image.file_path;
     }

--- a/src/opt/test/test_alignment.cc
+++ b/src/opt/test/test_alignment.cc
@@ -485,7 +485,7 @@ void Test4FrameAlignment(
           cv::resize(scale_depth_maps[i - 1], scale_depth_maps[i],
                       cv::Size(kDownscaleFactor * scale_depth_maps[i - 1].cols,
                               kDownscaleFactor * scale_depth_maps[i - 1].rows),
-                      kDownscaleFactor, kDownscaleFactor, CV_INTER_AREA);
+                      kDownscaleFactor, kDownscaleFactor, cv::INTER_AREA);
           if (scale_depth_maps[i].empty()) {
             LOG(FATAL) << "Resizing failed";
           }

--- a/src/opt/test/test_alignment_util.cc
+++ b/src/opt/test/test_alignment_util.cc
@@ -135,7 +135,7 @@ bool ProcessOnePair(const ImagePairInfo& info,
   std::string model_depth_absolute_path =
       (boost::filesystem::path(files_directory_path) / info.model_depth_path).string();
   cv::Mat_<uint16_t> model_depth_image =
-      cv::imread(model_depth_absolute_path, CV_LOAD_IMAGE_UNCHANGED);
+      cv::imread(model_depth_absolute_path, cv::IMREAD_UNCHANGED);
   if (model_depth_image.empty()) {
     std::cout << "  SKIP: Cannot read depth image at path "
               << model_depth_absolute_path << std::endl;


### PR DESCRIPTION
Hi and thanks for this repo ! Started working on it recently, especially to make it work with Ubuntu16, PCL1.9 Opencv4 and QT5.

This Pull request is about linking Opencv to BaseLib.
Opencv4 has a new layout that makes the include and .so files not available if you only give the directories /usr/local/include and /usr/local/lib to work with.
More generally, if Opencv is installed elsewhere, you will have problems too.

The faulty file is [`visibility_estimator.cc`](https://github.com/ETH3D/dataset-pipeline/blob/master/src/opt/visibility_estimator.cc#L32), which tries to include `<opencv2/highgui/highgui.hpp>`

This is avoided by linking BaseLib against opencv as the first commit does.

The following two commits are dealing with deprecated opencv function.
Namely, Matrices of `size_t` are no longer accepted since Opencv3.3, and some enum variables like e.g. `CV_LOAD_IMAGE_GRAYSCALE` are deprecated since Opencv4 .