### PR TITLE
Generate for video

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ For this example, the pipeline is run on the "terrace" DSLR training dataset of 
   mkdir dslr_calibration_jpg
   ${PIPELINE_PATH}/ImageRegistrator \
       --scan_alignment_path scan_clean/scan_alignment.mlp \
-      --occlusion_mesh_paths surface_reconstruction/surface.ply,surface_reconstruction/splats.ply \
+      --occlusion_mesh_path surface_reconstruction/surface.ply \
+      --occlusion_splats_path surface_reconstruction/splats.ply \
       --multi_res_point_cloud_directory_path multi_res_point_cloud_cache \
       --image_base_path . \
       --state_path sparse_reconstruction_scaled/colmap_model \
@@ -137,7 +138,8 @@ For this example, the pipeline is run on the "terrace" DSLR training dataset of 
   ```
   ${PIPELINE_PATH}/ImageRegistrator \
       --scan_alignment_path scan_clean/scan_alignment.mlp \
-      --occlusion_mesh_paths surface_reconstruction/surface.ply,surface_reconstruction/splats.ply \
+      --occlusion_mesh_path surface_reconstruction/surface.ply \
+      --occlusion_splats_path surface_reconstruction/splats.ply \
       --multi_res_point_cloud_directory_path multi_res_point_cloud_cache \
       --image_base_path . \
       --state_path dslr_calibration_jpg/scale_0.0625_state \
@@ -154,7 +156,8 @@ For this example, the pipeline is run on the "terrace" DSLR training dataset of 
   ```
   ${PIPELINE_PATH}/DatasetInspector \
       --scan_alignment_path scan_clean/scan_alignment.mlp \
-      --occlusion_mesh_paths surface_reconstruction/surface.ply,surface_reconstruction/splats.ply \
+      --occlusion_mesh_path surface_reconstruction/surface.ply \
+      --occlusion_splats_path surface_reconstruction/splats.ply \
       --multi_res_point_cloud_directory_path multi_res_point_cloud_cache \
       --image_base_path . \
       --state_path dslr_calibration_jpg/scale_1_state
@@ -163,7 +166,8 @@ For this example, the pipeline is run on the "terrace" DSLR training dataset of 
   ```
   ${PIPELINE_PATH}/GroundTruthCreator \
       --scan_alignment_path scan_clean/scan_alignment.mlp \
-      --occlusion_mesh_paths surface_reconstruction/surface.ply,surface_reconstruction/splats.ply \
+      --occlusion_mesh_path surface_reconstruction/surface.ply \
+      --occlusion_splats_path surface_reconstruction/splats.ply \
       --image_base_path . \
       --state_path dslr_calibration_jpg/scale_1_state \
       --output_folder_path ground_truth \
@@ -231,7 +235,8 @@ Most of the steps are identical to the previous example.
   mkdir rig_calibration
   ${PIPELINE_PATH}/ImageRegistrator \
       --scan_alignment_path scan_clean/scan_alignment.mlp \
-      --occlusion_mesh_paths surface_reconstruction/surface.ply,surface_reconstruction/splats.ply \
+      --occlusion_mesh_path surface_reconstruction/surface.ply \
+      --occlusion_splats_path surface_reconstruction/splats.ply \
       --multi_res_point_cloud_directory_path multi_res_point_cloud_cache \
       --image_base_path . \
       --state_path sparse_reconstruction_scaled/colmap_model \
@@ -243,7 +248,8 @@ Most of the steps are identical to the previous example.
   ```
   ${PIPELINE_PATH}/ImageRegistrator \
       --scan_alignment_path scan_clean/scan_alignment.mlp \
-      --occlusion_mesh_paths surface_reconstruction/surface.ply,surface_reconstruction/splats.ply \
+      --occlusion_mesh_path surface_reconstruction/surface.ply \
+      --occlsuion_splats_path surface_reconstruction/splats.ply \
       --multi_res_point_cloud_directory_path multi_res_point_cloud_cache \
       --image_base_path . \
       --state_path dslr_calibration_jpg/scale_0.0625_state \
@@ -260,7 +266,8 @@ Most of the steps are identical to the previous example.
   ```
   ${PIPELINE_PATH}/DatasetInspector \
       --scan_alignment_path scan_clean/scan_alignment.mlp \
-      --occlusion_mesh_paths surface_reconstruction/surface.ply,surface_reconstruction/splats.ply \
+      --occlusion_mesh_path surface_reconstruction/surface.ply \
+      --occlusion_splats_path surface_reconstruction/splats.ply \
       --multi_res_point_cloud_directory_path multi_res_point_cloud_cache \
       --image_base_path . \
       --state_path rig_calibration/scale_1_state
@@ -269,7 +276,8 @@ Most of the steps are identical to the previous example.
   ```
   ${PIPELINE_PATH}/GroundTruthCreator \
       --scan_alignment_path scan_clean/scan_alignment.mlp \
-      --occlusion_mesh_paths surface_reconstruction/surface.ply,surface_reconstruction/splats.ply \
+      --occlusion_mesh_path surface_reconstruction/surface.ply \
+      --occlusion_splats_path surface_reconstruction/splats.ply \
       --image_base_path . \
       --state_path rig_calibration/scale_1_state \
       --output_folder_path ground_truth \
@@ -742,7 +750,8 @@ The `DatasetInspector` can be run as in the following example:
 ```
 DatasetInspector \
     --scan_alignment_path scan_alignment.mlp \
-    --occlusion_mesh_paths surface.ply,splats.ply \
+    --occlusion_mesh_path surface.ply \
+    --occlusion_splats_path splats.ply \
     --multi_res_point_cloud_directory_path multi_res_point_cloud_cache \
     --image_base_path . \
     --state_path state_path
@@ -1011,7 +1020,8 @@ A typical invocation looks as in the following example:
 ```
 ImageRegistrator \
     --scan_alignment_path scan_alignment.mlp \
-    --occlusion_mesh_paths surface.ply,splats.ply \
+    --occlusion_mesh_path surface.ply \
+    --occlusion_splats_path splats.ply \
     --multi_res_point_cloud_directory_path multi_res_point_cloud_cache \
     --image_base_path . \
     --state_path colmap_model \
@@ -1060,7 +1070,8 @@ Usage of the tool is as in the following example:
 ```
 GroundTruthCreator \
     --scan_alignment_path scan_alignment.mlp \
-    --occlusion_mesh_paths surface.ply,splats.ply \
+    --occlusion_mesh_path surface.ply \
+    --occlusion_splats_path splats.ply \
     --image_base_path . \
     --state_path scale_1_state \
     --output_folder_path ground_truth \

--- a/src/base/util.h
+++ b/src/base/util.h
@@ -34,26 +34,6 @@
 
 #include <boost/filesystem.hpp>
 
-inline void hash_combine(std::size_t& seed) { }
-
-template <typename T, typename... Rest>
-inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
-    std::hash<T> hasher;
-    seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-    hash_combine(seed, rest...);
-}
-
-#define MAKE_HASHABLE(type, ...) \
-    namespace std {\
-        template<> struct hash<type> {\
-            std::size_t operator()(const type &t) const {\
-                std::size_t ret = 0;\
-                hash_combine(ret, __VA_ARGS__);\
-                return ret;\
-            }\
-        };\
-    }
-
 namespace util {
 
 boost::filesystem::path RelativePath(boost::filesystem::path from,

--- a/src/camera/camera_base_impl.h
+++ b/src/camera/camera_base_impl.h
@@ -282,8 +282,9 @@ template <class Child> class CameraBaseImpl : public CameraBase {
       Eigen::MatrixBase<Derived2>* second_best_result,
       bool* second_best_available) const {
     // Try different initialization points and take the result with the smallest
-    // radius. Since this should be the only acceptable one, also store the second
-    // smallest result. Thus we know the radius cutoff should be between the two
+    // radius. Cutoff radius must be above this result.
+    // Besides, since this should be the only acceptable one, al other resultats are above cutoff.
+    // Thus, store the second smallest result so that we know the radius cutoff should be between the two
     constexpr int kNumGridSteps = 10;
     constexpr float kGridHalfExtent = 1.5f;
     constexpr float kImproveThreshold = 0.99f;

--- a/src/camera/test/test_camera.cc
+++ b/src/camera/test/test_camera.cc
@@ -364,7 +364,7 @@ void TestParameterStorage() {
 
   float parameters[kNumParameters];
   for (int i = 0; i < kNumParameters; ++ i) {
-    parameters[i] = 10 * i;
+    parameters[i] = 1 + 10 * i;
   }
   Camera camera(10, 10, parameters);
 
@@ -433,7 +433,7 @@ TEST(Camera, SimplePinhole) {
 
 TEST(Camera, Radial) {
   camera::RadialCamera radial_camera(kImageWidth, kImageHeight,
-                                     kFX, kCX, kCY, -0.5*kK1, 0);
+                                     kFX, kCX, kCY, kK1, -1e-2);
   RunCameraModelTests(radial_camera);
 }
 

--- a/src/dataset_inspector/gui_image_widget.cc
+++ b/src/dataset_inspector/gui_image_widget.cc
@@ -227,7 +227,9 @@ void ImageWidget::paintEvent(QPaintEvent* event) {
         
         cv::Mat_<float> occlusion_image =
             problem_->occlusion_geometry().RenderDepthMap(
-                *intrinsics_, *image_, display_image_scale);
+                *intrinsics_, *image_, display_image_scale,
+                opt::GlobalParameters().min_occlusion_depth,
+                opt::GlobalParameters().max_occlusion_depth);
         occlusion_depth_map_.create(occlusion_image.rows, occlusion_image.cols);
         for (int y = 0; y < occlusion_image.rows; ++ y) {
           for (int x = 0; x < occlusion_image.cols; ++ x) {
@@ -526,7 +528,9 @@ void ImageWidget::UpdateScanPoints(
   scan_points_.reserve(64000);
   
   cv::Mat_<float> occlusion_image = problem_->occlusion_geometry().RenderDepthMap(
-      intrinsics, image, display_image_scale);
+      intrinsics, image, display_image_scale,
+      opt::GlobalParameters().min_occlusion_depth,
+      opt::GlobalParameters().max_occlusion_depth);
   
   Eigen::Matrix3f image_R_global = image_->image_T_global.so3().matrix();
   Eigen::Vector3f image_T_global = image_->image_T_global.translation();
@@ -600,6 +604,8 @@ void ImageWidget::UpdateDepthMap(
     bool mask_occlusion_boundaries) {
   cv::Mat_<float> occlusion_image = problem_->occlusion_geometry().RenderDepthMap(
       intrinsics, image, display_image_scale,
+      opt::GlobalParameters().min_occlusion_depth,
+      opt::GlobalParameters().max_occlusion_depth,
       mask_occlusion_boundaries);
   
   Eigen::Matrix3f image_R_global = image.image_T_global.so3().matrix();

--- a/src/dataset_inspector/gui_image_widget.cc
+++ b/src/dataset_inspector/gui_image_widget.cc
@@ -126,6 +126,11 @@ void ImageWidget::SetShowMask(bool show_mask) {
   update(rect());
 }
 
+void ImageWidget::SetMaxOccDepth(float max_occ_depth) {
+  max_occ_depth_ = max_occ_depth;
+  update(rect());
+}
+
 QSize ImageWidget::sizeHint() const {
   // Relatively arbitrary setting.
   return QSize(640, 480);
@@ -226,7 +231,7 @@ void ImageWidget::paintEvent(QPaintEvent* event) {
         occlusion_depth_map_.create(occlusion_image.rows, occlusion_image.cols);
         for (int y = 0; y < occlusion_image.rows; ++ y) {
           for (int x = 0; x < occlusion_image.cols; ++ x) {
-            occlusion_depth_map_(y, x) = std::min<int>(255, 255.f / 20.f * occlusion_image(y, x));
+            occlusion_depth_map_(y, x) = std::min<int>(255, 255.f / max_occ_depth_ * occlusion_image(y, x));
           }
         }
       }
@@ -594,7 +599,8 @@ void ImageWidget::UpdateDepthMap(
     int display_image_scale,
     bool mask_occlusion_boundaries) {
   cv::Mat_<float> occlusion_image = problem_->occlusion_geometry().RenderDepthMap(
-      intrinsics, image, display_image_scale, mask_occlusion_boundaries);
+      intrinsics, image, display_image_scale,
+      mask_occlusion_boundaries);
   
   Eigen::Matrix3f image_R_global = image.image_T_global.so3().matrix();
   Eigen::Vector3f image_T_global = image.image_T_global.translation();

--- a/src/dataset_inspector/gui_image_widget.h
+++ b/src/dataset_inspector/gui_image_widget.h
@@ -126,6 +126,8 @@ class ImageWidget : public QWidget
   
   void SetShowMask(bool show_mask);
 
+  void SetMaxOccDepth(float max_occ_depth);
+
   virtual QSize sizeHint() const;
   
   inline int display_image_scale() const { return display_image_scale_; }
@@ -217,6 +219,7 @@ class ImageWidget : public QWidget
   // Cached occlusion depth map data.
   int occlusion_map_image_id_;
   int occlusion_map_image_scale_;
+  float max_occ_depth_; // For vizualisation purpose
   cv::Mat_<uint8_t> occlusion_depth_map_;
   
   // Cached depth map data.

--- a/src/dataset_inspector/gui_main_window.cc
+++ b/src/dataset_inspector/gui_main_window.cc
@@ -876,10 +876,14 @@ void MainWindow::TransferLabels(
   LOG(INFO) << "Label transfer: compute occlusion images ...";
   cv::Mat_<float> source_occlusion_image =
       problem_->occlusion_geometry().RenderDepthMap(
-          source_intrinsics, *source_image, source_intrinsics.min_image_scale);
+          source_intrinsics, *source_image, source_intrinsics.min_image_scale,
+          opt::GlobalParameters().min_occlusion_depth,
+          opt::GlobalParameters().max_occlusion_depth);
   cv::Mat_<float> target_occlusion_image =
       problem_->occlusion_geometry().RenderDepthMap(
-          target_intrinsics, *target_image, target_intrinsics.min_image_scale);
+          target_intrinsics, *target_image, target_intrinsics.min_image_scale,
+          opt::GlobalParameters().min_occlusion_depth,
+          opt::GlobalParameters().max_occlusion_depth);
   
   LOG(INFO) << "Label transfer: project points ...";
   Eigen::Matrix3f source_R_global = source_image->image_T_global.rotationMatrix();

--- a/src/dataset_inspector/gui_main_window.cc
+++ b/src/dataset_inspector/gui_main_window.cc
@@ -58,7 +58,8 @@
 
 namespace dataset_inspector {
 
-MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
+MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags,
+                       bool optimization_tools, const float max_occ_depth)
     : QMainWindow(parent, flags) {
   current_image_id_ = opt::Image::kInvalidId;
   
@@ -113,6 +114,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   // ### Image display ###
   image_widget_ = new ImageWidget();
   image_widget_->SetShowMask(kShowMasksByDefault);
+  image_widget_->SetMaxOccDepth(max_occ_depth);
   horizontal_layout->addWidget(image_widget_, 1);
   
   
@@ -265,11 +267,13 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   new_item->setText("scan reprojection");
   new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kScanReprojection)));
   mode_list_->addItem(new_item);
-  
-  new_item = new QListWidgetItem();
-  new_item->setText("optimization points");
-  new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kOptimizationPoints)));
-  mode_list_->addItem(new_item);
+
+  if(optimization_tools){
+    new_item = new QListWidgetItem();
+    new_item->setText("optimization points");
+    new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kOptimizationPoints)));
+    mode_list_->addItem(new_item);
+  }
   
   new_item = new QListWidgetItem();
   new_item->setText("depth map");
@@ -290,26 +294,28 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   new_item->setText("occlusion depth map");
   new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kOcclusionDepthMap)));
   mode_list_->addItem(new_item);
-  
-  new_item = new QListWidgetItem();
-  new_item->setText("cost (fixed)");
-  new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kCostFixed)));
-  mode_list_->addItem(new_item);
-  
-  new_item = new QListWidgetItem();
-  new_item->setText("cost (fixed) - highest 80% only");
-  new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kCostFixedHighestOnly)));
-  mode_list_->addItem(new_item);
-  
-  new_item = new QListWidgetItem();
-  new_item->setText("cost (variable)");
-  new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kCostVariable)));
-  mode_list_->addItem(new_item);
-  
-  new_item = new QListWidgetItem();
-  new_item->setText("cost (fixed + variable)");
-  new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kCostFixedPlusVariable)));
-  mode_list_->addItem(new_item);
+
+  if(optimization_tools){
+    new_item = new QListWidgetItem();
+    new_item->setText("cost (fixed)");
+    new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kCostFixed)));
+    mode_list_->addItem(new_item);
+
+    new_item = new QListWidgetItem();
+    new_item->setText("cost (fixed) - highest 80% only");
+    new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kCostFixedHighestOnly)));
+    mode_list_->addItem(new_item);
+
+    new_item = new QListWidgetItem();
+    new_item->setText("cost (variable)");
+    new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kCostVariable)));
+    mode_list_->addItem(new_item);
+
+    new_item = new QListWidgetItem();
+    new_item->setText("cost (fixed + variable)");
+    new_item->setData(Qt::UserRole, QVariant(static_cast<int>(Mode::kCostFixedPlusVariable)));
+    mode_list_->addItem(new_item);
+  }
   
   
   // Set default tool.

--- a/src/dataset_inspector/gui_main_window.cc
+++ b/src/dataset_inspector/gui_main_window.cc
@@ -324,13 +324,15 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags,
 
 bool MainWindow::LoadDataset(
     const std::string& scan_alignment_path,
-    const std::vector<std::string>& occlusion_mesh_paths,
+    const std::string& occlusion_mesh_path,
+    const std::string& splat_mesh_path,
     const std::string& multi_res_point_cloud_directory_path,
     const std::string& image_base_path,
     const std::string& state_path,
     const std::unordered_set<int>& camera_ids_to_ignore) {
   scan_alignment_path_ = scan_alignment_path;
-  occlusion_mesh_paths_ = occlusion_mesh_paths;
+  occlusion_mesh_path_ = occlusion_mesh_path;
+  splat_mesh_path_ = splat_mesh_path;
   image_base_path_ = image_base_path;
   state_path_ = state_path;
   
@@ -703,9 +705,10 @@ void MainWindow::EditOcclusionGeometryClicked(bool /*checked*/) {
   editor_window->OpenFile(QString::fromStdString(scan_alignment_path_));
   
   // Open occlusion meshes
-  for (const std::string path : occlusion_mesh_paths_) {
-    editor_window->OpenFile(QString::fromStdString(path));
-  }
+  if(!occlusion_mesh_path_.empty())
+    editor_window->OpenFile(QString::fromStdString(occlusion_mesh_path_));
+  if(!splat_mesh_path_.empty())
+    editor_window->OpenFile(QString::fromStdString(splat_mesh_path_));
 }
 
 void MainWindow::ReloadOcclusionGeometryClicked(bool /*checked*/) {
@@ -715,20 +718,27 @@ void MainWindow::ReloadOcclusionGeometryClicked(bool /*checked*/) {
   
   if (editor_window) {
     // Reload from editor.
+    const opt::OcclusionGeometry& old_occlusion_geometry = problem_->occlusion_geometry();
+    const auto& metadata_vector = old_occlusion_geometry.MetadataVector();
+
     std::shared_ptr<opt::OcclusionGeometry> occlusion_geometry(new opt::OcclusionGeometry());
-    std::vector<bool> occlusion_mesh_found(occlusion_mesh_paths_.size(), false);
+    std::vector<bool> occlusion_mesh_found(
+      metadata_vector.size(), false);
     
     pcl::PolygonMesh polygon_mesh;
     for (int i = 0; i < editor_window->scene().object_count(); ++ i) {
       const point_cloud_editor::Object& object = editor_window->scene().object(i);
       boost::filesystem::path object_path = object.filename;
       
-      for (std::size_t i = 0; i < occlusion_mesh_paths_.size(); ++ i) {
-        const std::string& path = occlusion_mesh_paths_[i];
+      for (std::size_t i = 0; i < metadata_vector.size(); ++ i) {
+        const auto& metadata = metadata_vector[i];
+        const std::string& path = metadata.file_path;
         if (object_path == boost::filesystem::path(path)) {
+          LOG(INFO) << path;
           occlusion_mesh_found[i] = true;
           object.ToPCLPolygonMesh(&polygon_mesh);
-          occlusion_geometry->AddMesh(polygon_mesh);
+          occlusion_geometry->AddMesh(polygon_mesh, metadata.transformation, metadata.compute_edges);
+          LOG(INFO) << "Done.";
         }
       }
     }
@@ -1159,7 +1169,7 @@ float MainWindow::GetRotationStep() {
 bool MainWindow::ReloadOcclusionGeometry(std::vector<pcl::PointCloud<pcl::PointXYZRGB>::Ptr>* colored_scans) {
   std::shared_ptr<opt::OcclusionGeometry> occlusion_geometry(new opt::OcclusionGeometry());
   
-  if (occlusion_mesh_paths_.empty()) {
+  if (occlusion_mesh_path_.empty() && splat_mesh_path_.empty()) {
     std::vector<pcl::PointCloud<pcl::PointXYZRGB>::Ptr> local_colored_scans;
     if (!colored_scans) {
       colored_scans = &local_colored_scans;
@@ -1187,9 +1197,10 @@ bool MainWindow::ReloadOcclusionGeometry(std::vector<pcl::PointCloud<pcl::PointX
     
     occlusion_geometry->SetSplatPoints(occlusion_point_cloud);
   } else {
-    for (const std::string& mesh_file_path : occlusion_mesh_paths_) {
-      occlusion_geometry->AddMesh(mesh_file_path);
-    }
+    if(!occlusion_mesh_path_.empty())
+      occlusion_geometry->AddMesh(occlusion_mesh_path_);
+    if(!splat_mesh_path_.empty())
+      occlusion_geometry->AddSplats(splat_mesh_path_);
   }
   
   // Put the geometry into the optimization problem.

--- a/src/dataset_inspector/gui_main_window.h
+++ b/src/dataset_inspector/gui_main_window.h
@@ -64,7 +64,10 @@ enum class Mode {
 class MainWindow : public QMainWindow {
  Q_OBJECT
  public:
-  MainWindow(QWidget* parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
+  MainWindow(QWidget* parent = nullptr,
+             Qt::WindowFlags flags = Qt::WindowFlags(),
+             bool optimization_tools=true,
+             float max_occ_depth=20.f);
   
   bool LoadDataset(
       const std::string& scan_alignment_path,

--- a/src/dataset_inspector/gui_main_window.h
+++ b/src/dataset_inspector/gui_main_window.h
@@ -71,7 +71,8 @@ class MainWindow : public QMainWindow {
   
   bool LoadDataset(
       const std::string& scan_alignment_path,
-      const std::vector<std::string>& occlusion_mesh_paths,
+      const std::string& occlusion_mesh_path,
+      const std::string& splat_mesh_path,
       const std::string& multi_res_point_cloud_directory_path,
       const std::string& image_base_path,
       const std::string& state_path,
@@ -195,7 +196,8 @@ class MainWindow : public QMainWindow {
   int current_image_id_;
   std::shared_ptr<opt::Problem> problem_;
   std::string scan_alignment_path_;
-  std::vector<std::string> occlusion_mesh_paths_;
+  std::string occlusion_mesh_path_;
+  std::string splat_mesh_path_;
   std::string image_base_path_;
   std::string state_path_;
 };

--- a/src/exe/dataset_inspector.cc
+++ b/src/exe/dataset_inspector.cc
@@ -51,9 +51,11 @@ int main(int argc, char** argv) {
   std::string scan_alignment_path;
   pcl::console::parse_argument(argc, argv, "--scan_alignment_path", scan_alignment_path);
   
-  std::string occlusion_mesh_paths;
-  pcl::console::parse_argument(argc, argv, "--occlusion_mesh_paths", occlusion_mesh_paths);
-  std::vector<std::string> occlusion_mesh_paths_vector = util::SplitString(',', occlusion_mesh_paths);
+  std::string occlusion_mesh_path;
+  pcl::console::parse_argument(argc, argv, "--occlusion_mesh_path", occlusion_mesh_path);
+
+  std::string occlusion_splats_path;
+  pcl::console::parse_argument(argc, argv, "--occlusion_splats_path", occlusion_splats_path);
   
   std::string multi_res_point_cloud_directory_path;
   pcl::console::parse_argument(argc, argv, "--multi_res_point_cloud_directory_path", multi_res_point_cloud_directory_path);
@@ -87,7 +89,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  if(occlusion_mesh_paths.empty()){
+  if(occlusion_mesh_path.empty() && occlusion_splats_path.empty()){
     LOG(WARNING) << "No occlusion mesh specifed, "
                  << "2D splats from the scan point cloud will be used.";
   }
@@ -104,7 +106,8 @@ int main(int argc, char** argv) {
   dataset_inspector::MainWindow main_window(nullptr, Qt::WindowFlags(), optimization_tools, max_occ_depth);
   main_window.LoadDataset(
       scan_alignment_path,
-      occlusion_mesh_paths_vector,
+      occlusion_mesh_path,
+      occlusion_splats_path,
       multi_res_point_cloud_directory_path,
       image_base_path,
       state_path,

--- a/src/exe/dataset_inspector.cc
+++ b/src/exe/dataset_inspector.cc
@@ -72,24 +72,36 @@ int main(int argc, char** argv) {
   for (const std::string& id_to_ignore : camera_ids_to_ignore_split) {
     camera_ids_to_ignore.insert(atoi(id_to_ignore.c_str()));
   }
+
+  float max_occ_depth = 20.f;
+  pcl::console::parse_argument(argc, argv, "--occlusion_depth_saturation", max_occ_depth);
   
   opt::GlobalParameters().SetFromArguments(argc, argv);
   
   
   // Verify arguments.
   if (scan_alignment_path.empty() ||
-      occlusion_mesh_paths.empty() ||
-      multi_res_point_cloud_directory_path.empty() ||
       image_base_path.empty() ||
       state_path.empty()) {
     LOG(ERROR) << "Please specify all the required paths.";
     return EXIT_FAILURE;
   }
+
+  if(occlusion_mesh_paths.empty()){
+    LOG(WARNING) << "No occlusion mesh specifed, "
+                 << "2D splats from the scan point cloud will be used.";
+  }
+
+  bool optimization_tools = !multi_res_point_cloud_directory_path.empty();
+  if(!optimization_tools){
+    LOG(WARNING) << "No multi resolution cloud path specified, "
+                << "Interface will not show cost points and optimization elements";
+  }
   
   // Run application.
   QApplication qapp(argc, argv);
   
-  dataset_inspector::MainWindow main_window(nullptr, Qt::WindowFlags());
+  dataset_inspector::MainWindow main_window(nullptr, Qt::WindowFlags(), optimization_tools, max_occ_depth);
   main_window.LoadDataset(
       scan_alignment_path,
       occlusion_mesh_paths_vector,

--- a/src/exe/ground_truth_creator.cc
+++ b/src/exe/ground_truth_creator.cc
@@ -51,7 +51,9 @@ void AccumulateScanObservationsForImage(
     const std::vector<pcl::PointCloud<pcl::PointXYZRGB>::Ptr>& colored_scans,
     std::vector<std::vector<int>>* observation_counts) {
   cv::Mat_<float> occlusion_image = problem.occlusion_geometry().RenderDepthMap(
-      intrinsics, image, intrinsics.min_image_scale);
+      intrinsics, image, intrinsics.min_image_scale,
+      opt::GlobalParameters().min_occlusion_depth,
+      opt::GlobalParameters().max_occlusion_depth);
   std::string image_mask_path = image.GetImageMaskPath();
   cv::Mat_<uint8_t> mask;
   if (boost::filesystem::exists(image_mask_path)) {

--- a/src/exe/ground_truth_creator.cc
+++ b/src/exe/ground_truth_creator.cc
@@ -31,6 +31,7 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <pcl/console/parse.h>
+#include <pcl/common/transforms.h>
 #include <pcl/io/ply_io.h>
 #include <zlib.h>
 
@@ -337,7 +338,7 @@ int main(int argc, char** argv) {
     // Correct problem state (camera poses).
     for (auto& id_and_image : *problem.images_mutable()) {
       opt::Image* image = &id_and_image.second;
-      image->global_T_image = first_scan_up_transformation * image->global_T_image;
+      image->global_T_image = Sophus::SE3f(first_scan_up_transformation.matrix() * image->global_T_image.matrix());
       image->image_T_global = image->global_T_image.inverse();
     }
   }

--- a/src/exe/ground_truth_creator.cc
+++ b/src/exe/ground_truth_creator.cc
@@ -405,6 +405,7 @@ int main(int argc, char** argv) {
         boost::filesystem::path("points")).string();
     boost::filesystem::create_directories(output_points_folder_path);
     io::MeshLabMeshInfoVector out_info_vector = scan_infos;
+    #pragma omp parallel for
     for (size_t scan_index = 0; scan_index < scan_infos.size(); ++ scan_index) {
       const io::MeshLabProjectMeshInfo& scan_info = scan_infos[scan_index];
       const std::vector<int>& scan_observation_counts = observation_counts[scan_index];
@@ -452,7 +453,9 @@ int main(int argc, char** argv) {
     if(write_scan_renderings)
       LOG(INFO) << "Writing scan renderings ...";
     int current_image = 0;
+    #pragma omp parallel for
     for (std::size_t i = 0; i< images_nb; ++i){
+      #pragma omp critical
       std::cout << "Image [" << ++current_image << "/" << images_nb << "]\r" << std::flush;
       const opt::Image& image = problem.image(image_ids[i]);
       const opt::Intrinsics& intrinsics = problem.intrinsics(image.intrinsics_id);

--- a/src/exe/image_registrator.cc
+++ b/src/exe/image_registrator.cc
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
   pcl::console::parse_argument(argc, argv, "--scan_alignment_path", scan_alignment_path);
   
   std::string occlusion_mesh_path;
-  pcl::console::parse_argument(argc, argv, "--occlusion_mesh_paths", occlusion_mesh_path);
+  pcl::console::parse_argument(argc, argv, "--occlusion_mesh_path", occlusion_mesh_path);
 
   std::string occlusion_splats_path;
   pcl::console::parse_argument(argc, argv, "--occlusion_splats_path", occlusion_splats_path);
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
   }
   
   if (occlusion_mesh_path.empty() && occlusion_splats_path.empty()) {
-    LOG(WARNING) << "No occlusion meshes given, using splats.";
+    LOG(WARNING) << "No occlusion meshes given, using 2D splats.";
   }
   
   

--- a/src/exe/image_registrator.cc
+++ b/src/exe/image_registrator.cc
@@ -64,9 +64,11 @@ int main(int argc, char** argv) {
   std::string scan_alignment_path;
   pcl::console::parse_argument(argc, argv, "--scan_alignment_path", scan_alignment_path);
   
-  std::string occlusion_mesh_paths;
-  pcl::console::parse_argument(argc, argv, "--occlusion_mesh_paths", occlusion_mesh_paths);
-  std::vector<std::string> occlusion_mesh_paths_vector = util::SplitString(',', occlusion_mesh_paths);
+  std::string occlusion_mesh_path;
+  pcl::console::parse_argument(argc, argv, "--occlusion_mesh_paths", occlusion_mesh_path);
+
+  std::string occlusion_splats_path;
+  pcl::console::parse_argument(argc, argv, "--occlusion_splats_path", occlusion_splats_path);
   
   std::string multi_res_point_cloud_directory_path;
   pcl::console::parse_argument(argc, argv, "--multi_res_point_cloud_directory_path", multi_res_point_cloud_directory_path);
@@ -125,7 +127,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
   
-  if (occlusion_mesh_paths_vector.empty()) {
+  if (occlusion_mesh_path.empty() && occlusion_splats_path.empty()) {
     LOG(WARNING) << "No occlusion meshes given, using splats.";
   }
   
@@ -160,12 +162,13 @@ int main(int argc, char** argv) {
   
   // Create occlusion geometry.
   std::shared_ptr<opt::OcclusionGeometry> occlusion_geometry(new opt::OcclusionGeometry());
-  if (occlusion_mesh_paths_vector.empty()) {
+  if (occlusion_mesh_path.empty() && occlusion_splats_path.empty()) {
     occlusion_geometry->SetSplatPoints(occlusion_point_cloud);
   } else {
-    for (const std::string& mesh_file_path : occlusion_mesh_paths_vector) {
-      occlusion_geometry->AddMesh(mesh_file_path);
-    }
+    if(!occlusion_mesh_path.empty())
+      occlusion_geometry->AddMesh(occlusion_mesh_path);
+    if(!occlusion_splats_path.empty())
+      occlusion_geometry->AddSplats(occlusion_splats_path);
   }
   
   // Allocate optimization problem object.
@@ -263,7 +266,8 @@ int main(int argc, char** argv) {
     // Write meta data.
     std::ofstream metadata_stream((boost::filesystem::path(state_path) / "metadata.txt").string(), std::ios::out);
     metadata_stream << "scan_alignment_path " << scan_alignment_path << std::endl;
-    metadata_stream << "occlusion_mesh_paths " << occlusion_mesh_paths << std::endl;
+    metadata_stream << "occlusion_mesh_path " << occlusion_mesh_path << std::endl;
+    metadata_stream << "occlusion_splats_path " << occlusion_splats_path << std::endl;
     metadata_stream << "multi_res_point_cloud_directory_path " << multi_res_point_cloud_directory_path << std::endl;
     metadata_stream << "image_base_path " << image_base_path << std::endl;
     metadata_stream << "state_path " << state_path << std::endl;

--- a/src/exe/normal_estimator.cc
+++ b/src/exe/normal_estimator.cc
@@ -55,6 +55,8 @@ int main(int argc, char** argv) {
   pcl::console::parse_argument(argc, argv, "-o", ply_output_path);
   int neighbor_count = 8;
   pcl::console::parse_argument(argc, argv, "--neighbor_count", neighbor_count);
+  float neighbor_radius = -1;
+  pcl::console::parse_argument(argc, argv, "--neighbor_radius", neighbor_radius);
   
   if (meshlab_project_input_path.empty() || ply_output_path.empty()) {
     std::cout << "Please provide input paths." << std::endl;
@@ -175,7 +177,12 @@ int main(int argc, char** argv) {
     normal_estimation.setInputCloud(global_scan_cloud);
     pcl::search::KdTree<pcl::PointXYZRGB>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZRGB>());
     normal_estimation.setSearchMethod(tree);
-    normal_estimation.setKSearch(neighbor_count);
+    if(neighbor_radius > 0){
+      normal_estimation.setRadiusSearch(neighbor_radius);
+    }else{
+      normal_estimation.setKSearch(neighbor_count);
+    }
+    
     // normal_estimation.setSearchSurface(point_cloud);
     normal_estimation.setViewPoint(
         scan_info.global_T_mesh.translation().x(),

--- a/src/exe/splat_creator.cc
+++ b/src/exe/splat_creator.cc
@@ -87,6 +87,8 @@ int main(int argc, char** argv) {
   pcl::console::parse_argument(argc, argv, "--output_path", output_path);
   float distance_threshold = 0.02f;
   pcl::console::parse_argument(argc, argv, "--distance_threshold", distance_threshold);
+  float max_splat_size = std::numeric_limits<float>::infinity();;
+  pcl::console::parse_argument(argc, argv, "--max_plat_size", max_splat_size);
   const float squared_distance_threshold = distance_threshold * distance_threshold;
   
   if (point_normal_cloud_path.empty() || mesh_path.empty() || output_path.empty()) {
@@ -148,7 +150,7 @@ int main(int argc, char** argv) {
     CHECK_EQ(search_tree->nearestKSearch(
         point_normal, kNearestNeighborCount + 1, indices, squared_distances),
         kNearestNeighborCount + 1);
-    float splat_radius = sqrtf(squared_distances[kNearestNeighborCount]);
+    float splat_radius = std::min(sqrtf(squared_distances[kNearestNeighborCount]), max_splat_size);
     
     // Find (random) right and up vectors corresponding to the normal.
     Eigen::Vector3f right = point_normal.getNormalVector3fMap().unitOrthogonal();

--- a/src/io/meshlab_project.cc
+++ b/src/io/meshlab_project.cc
@@ -69,7 +69,7 @@ bool ReadMeshLabProject(const std::string& project_file_path, MeshLabMeshInfoVec
       mlmatrix44_stream >> M(2, 0) >> M(2, 1) >> M(2, 2) >> M(2, 3);
       mlmatrix44_stream >> M(3, 0) >> M(3, 1) >> M(3, 2) >> M(3, 3);
       new_mesh.global_T_mesh_full = M;
-      new_mesh.global_T_mesh = Sophus::SE3f(M.block<3, 3>(0, 0), M.block<3, 1>(0, 3));
+      new_mesh.global_T_mesh = Sophus::Sim3f(M);
     } else {
       // Default-constructed transformation will be identity.
     }
@@ -101,7 +101,7 @@ bool WriteMeshLabProject(const std::string& project_file_path, const MeshLabMesh
     mlmatrix44_stream << std::endl;
     // The spaces at the end are important. If omitted, MeshLab will crash when
     // opening the file.
-    Eigen::Matrix3f R = mesh.global_T_mesh.so3().matrix();
+    Eigen::Matrix3f R = mesh.global_T_mesh.rotationMatrix();
     mlmatrix44_stream << R(0, 0) << " " << R(0, 1) << " " << R(0, 2) << " " << mesh.global_T_mesh.translation()(0) << " " << std::endl;
     mlmatrix44_stream << R(1, 0) << " " << R(1, 1) << " " << R(1, 2) << " " << mesh.global_T_mesh.translation()(1) << " " << std::endl;
     mlmatrix44_stream << R(2, 0) << " " << R(2, 1) << " " << R(2, 2) << " " << mesh.global_T_mesh.translation()(2) << " " << std::endl;

--- a/src/io/meshlab_project.h
+++ b/src/io/meshlab_project.h
@@ -32,6 +32,7 @@
 
 #include <boost/filesystem.hpp>
 #include <sophus/se3.hpp>
+#include <sophus/sim3.hpp>
 #include <pcl/common/transforms.h>
 #include <pcl/io/ply_io.h>
 #include <pcl/point_cloud.h>
@@ -50,7 +51,7 @@ struct MeshLabProjectMeshInfo {
   std::string filename;
   
   // Mesh-to-global transformation.
-  Sophus::SE3f global_T_mesh;
+  Sophus::Sim3f global_T_mesh;
   
   // Full transformation matrix (may not be a SE3 transformation after all).
   Eigen::Matrix4f global_T_mesh_full;

--- a/src/opengl/renderer.cc
+++ b/src/opengl/renderer.cc
@@ -745,6 +745,12 @@ Renderer::~Renderer() {
 void Renderer::BeginRendering(
     const Sophus::SE3f& transformation,
     const camera::CameraBase& camera, float min_depth, float max_depth) {
+  Renderer::BeginRendering(Sophus::Sim3f(transformation.matrix()), camera, min_depth, max_depth);
+}
+
+void Renderer::BeginRendering(
+    const Sophus::Sim3f& transformation,
+    const camera::CameraBase& camera, float min_depth, float max_depth) {
   // Get or create the shader program for this camera.
   RendererProgramBasePtr program;
   if (!render_color_ && render_depth_) {
@@ -907,6 +913,12 @@ void Renderer::CreateFrameBufferObject() {
 void Renderer::SetupProjection(
     const Sophus::SE3f& transformation, const camera::CameraBase& camera,
     float min_depth, float max_depth) {
+  Renderer::SetupProjection(Sophus::Sim3f(transformation.matrix()), camera, min_depth, max_depth);
+}
+
+void Renderer::SetupProjection(
+    const Sophus::Sim3f& transformation, const camera::CameraBase& camera,
+    float min_depth, float max_depth) {
   CHECK_GT(max_depth, min_depth);
   CHECK_GT(min_depth, 0);
 
@@ -941,7 +953,7 @@ void Renderer::SetupProjection(
   CHECK_OPENGL_NO_ERROR();
 
   // Model-view matrix construction.
-  Eigen::Matrix3f rotation = transformation.so3().matrix();
+  Eigen::Matrix3f rotation = transformation.rxso3().matrix();
   for (int i = 0; i < 3; i++) {
     for (int j = 0; j < 3; j++) {
       matrix[i + j * 4] = rotation(i, j);

--- a/src/opengl/renderer.h
+++ b/src/opengl/renderer.h
@@ -32,6 +32,7 @@
 
 #include <GL/glew.h>
 #include <GL/gl.h>
+#include <sophus/sim3.hpp>
 #include <sophus/se3.hpp>
 
 #include "camera/camera_models.h"
@@ -304,6 +305,9 @@ class Renderer {
   ~Renderer();
   
   void BeginRendering(
+      const Sophus::Sim3f& transformation,
+      const camera::CameraBase& camera, float min_depth, float max_depth);
+  void BeginRendering(
       const Sophus::SE3f& transformation,
       const camera::CameraBase& camera, float min_depth, float max_depth);
   void RenderTriangleList(
@@ -321,6 +325,10 @@ class Renderer {
 
  private:
   void CreateFrameBufferObject();
+
+  void SetupProjection(
+      const Sophus::Sim3f& transformation, const camera::CameraBase& camera,
+      float min_depth, float max_depth);
 
   void SetupProjection(
       const Sophus::SE3f& transformation, const camera::CameraBase& camera,

--- a/src/opt/multi_scale_point_cloud.cc
+++ b/src/opt/multi_scale_point_cloud.cc
@@ -41,14 +41,6 @@
 
 namespace opt {
 
-typedef Eigen::Vector3i VoxelCoordinate;
-
-}  // namespace opt
-
-MAKE_HASHABLE(opt::VoxelCoordinate, t.x(), t.y(), t.z())
-
-namespace opt {
-
 void MergeClosePoints(float merge_distance,
                       int num_scans,
                       const pcl::PointCloud<pcl::PointXYZ>::Ptr& in_points,

--- a/src/opt/occlusion_geometry.cc
+++ b/src/opt/occlusion_geometry.cc
@@ -117,10 +117,9 @@ cv::Mat_<float> OcclusionGeometry::RenderDepthMap(
     const Intrinsics& intrinsics,
     const Image& image,
     int image_scale,
-    bool mask_occlusion_boundaries,
-    float splat_radius_factor,
     float min_depth,
-    float max_depth) const {
+    float max_depth,
+    bool mask_occlusion_boundaries) const {
   constexpr bool kDebugShowDepthMaps = false;
   
   std::lock_guard<std::mutex> lock(mutable_mutex_);
@@ -133,7 +132,6 @@ cv::Mat_<float> OcclusionGeometry::RenderDepthMap(
     CHOOSE_CAMERA_TEMPLATE(
         image_scale_camera,
         depth_map = _RenderDepthMapWithSplatsCPU(
-            splat_radius_factor,
             intrinsics,
             image,
             image_scale,
@@ -187,14 +185,13 @@ cv::Mat_<float> OcclusionGeometry::RenderDepthMap(
                                   image_scale_camera.width());
       CHOOSE_CAMERA_TEMPLATE(
           image_scale_camera,
-          MaskOutOcclusionBoundaries(splat_radius_factor, _image_scale_camera, image, depth_map, &depth_map_2));
+          MaskOutOcclusionBoundaries(_image_scale_camera, image, depth_map, &depth_map_2));
       
       // Debug: show depth map.
       if (kDebugShowDepthMaps) {
         cv::imshow("Rendered depth image after near-occlusion discarding", depth_map_2 / 8.f);
         cv::waitKey(0);
       }
-      
       return depth_map_2;
     } else {
       return depth_map;
@@ -214,47 +211,50 @@ cv::Mat_<float> OcclusionGeometry::RenderDepthMap(
 
 template<class Camera>
 void OcclusionGeometry::MaskOutOcclusionBoundaries(
-    float splat_radius_factor,
     const Camera& camera,
     const Image& image,
     const cv::Mat_<float>& input,
     cv::Mat_<float>* output) const {
-  const int splat_radius =
-      std::max<int>(1, camera.width() * splat_radius_factor + 0.5f);
   
   Eigen::Vector3f image_position = image.global_T_image.translation();
   Eigen::Matrix3f image_R_global = image.image_T_global.so3().matrix();
   Eigen::Vector3f image_T_global = image.image_T_global.translation();
-  
-  // Copy input to output.
-  for (int y = 0; y < input.rows; ++ y) {
-    for (int x = 0; x < input.cols; ++ x) {
-      (*output)(y, x) = input(y, x);
-    }
-  }
-  
-  // Find all edges for which one adjacent face points towards the camera, and
-  // the other one away from it.
-  for (const std::shared_ptr<EdgesWithFaceNormalsMesh>& edges_with_face_normals : edge_meshes_) {
+
+  input.copyTo(*output);
+
+  // Method without normals:
+  // Find edges for which one adjacent surface goes above the plane made by edge and edge to image vectors,
+  // the other below
+  for (const auto& edges_with_face_normals : edge_meshes_) {
     const std::vector<EdgeWithFaces>& edges_with_faces = edges_with_face_normals->edges_with_faces;
     const pcl::PointCloud<pcl::PointXYZ>& vertices = *edges_with_face_normals->vertices;
     const Eigen::Matrix<float, 3, Eigen::Dynamic>& face_normals = edges_with_face_normals->face_normals;
     
     for (std::size_t i = 0, size = edges_with_faces.size(); i < size; ++ i) {
       const EdgeWithFaces& edge = edges_with_faces[i];
-      Eigen::Vector3f edge_to_image = image_position - vertices.at(edge.vertex_index1).getVector3fMap();
-      bool face1 = face_normals.col(edge.face_index1).dot(edge_to_image) > 0;
-      bool face2 = face_normals.col(edge.face_index2).dot(edge_to_image) > 0;
-      if (face1 != face2) {
-        // The edge is at an occlusion boundary. Draw splats along the edge if
-        // it is visible.
-        DrawSplatsAtEdgeIfVisible(splat_radius,
-                                  camera,
+      const Eigen::Vector3f endpoint1 = vertices.at(edge.vertex_index1).getVector3fMap();
+      const Eigen::Vector3f endpoint2 = vertices.at(edge.vertex_index2).getVector3fMap();
+      const Eigen::Vector3f edge_to_image = image_position - endpoint1;
+      if(edge.face_index2 == std::numeric_limits<std::size_t>::max()){
+        DrawSplatsAtEdgeIfVisible(camera,
                                   image_R_global,
                                   image_T_global,
-                                  vertices.at(edge.vertex_index1).getVector3fMap(),
-                                  vertices.at(edge.vertex_index2).getVector3fMap(),
-                                  input, output);
+                                  endpoint1,
+                                  endpoint2,
+                                  output);
+        continue;
+      }
+      bool face1 = face_normals.col(edge.face_index1).dot(edge_to_image) > 0;
+      bool face2 = face_normals.col(edge.face_index2).dot(edge_to_image) > 0;
+      if ((edge.opposite_normals && (face1 == face2)) || (face1 != face2 && !edge.opposite_normals)) {
+        // The edge is at an occlusion boundary. Draw splats along the edge if
+        // it is visible.
+        DrawSplatsAtEdgeIfVisible(camera,
+                                  image_R_global,
+                                  image_T_global,
+                                  endpoint1,
+                                  endpoint2,
+                                  output);
       }
     }
   }
@@ -262,96 +262,81 @@ void OcclusionGeometry::MaskOutOcclusionBoundaries(
 
 template<class Camera>
 void OcclusionGeometry::DrawSplatsAtEdgeIfVisible(
-    int splat_radius,
     const Camera& camera,
     const Eigen::Matrix3f& image_R_global,
     const Eigen::Vector3f& image_T_global,
     const Eigen::Vector3f& endpoint1,
     const Eigen::Vector3f& endpoint2,
-    const cv::Mat_<float>& input,
     cv::Mat_<float>* output) const {
-  Eigen::Vector3f image_endpoint1 = image_R_global * endpoint1 + image_T_global;
+  const Eigen::Vector3f image_endpoint1 = image_R_global * endpoint1 + image_T_global;
   if (image_endpoint1.z() <= 0) {
     // Simplification: Do not consider this edge.
     return;
   }
-  Eigen::Vector3f image_endpoint2 = image_R_global * endpoint2 + image_T_global;
+  const Eigen::Vector3f image_endpoint2 = image_R_global * endpoint2 + image_T_global;
   if (image_endpoint2.z() <= 0) {
     // Simplification: Do not consider this edge.
     return;
   }
-  Eigen::Vector2f pxy1 = camera.NormalizedToImage(Eigen::Vector2f(
-      image_endpoint1.x() / image_endpoint1.z(), image_endpoint1.y() / image_endpoint1.z()));
-  Eigen::Vector2f pxy2 = camera.NormalizedToImage(Eigen::Vector2f(
-      image_endpoint2.x() / image_endpoint2.z(), image_endpoint2.y() / image_endpoint2.z()));
-  Eigen::Vector2f dxy = pxy2 - pxy1;
-  // Not considering image distortion here.
-  float approximate_pixel_length = dxy.norm();
-  
-  constexpr int kMaxSplatPointCount = 15;
+  const Eigen::Vector3f endpoint_delta = image_endpoint2 - image_endpoint1;
+  constexpr int kMaxSplatPointCount = 150;
+  float splat_radius = GlobalParameters().splat_radius;
   int splat_point_count =
-      std::min(static_cast<int>(approximate_pixel_length + 0.5f),
-               kMaxSplatPointCount);
-  
-  Eigen::Vector3f endpoint_delta = endpoint2 - endpoint1;
+      1 + std::min(static_cast<int>(endpoint_delta.norm()/splat_radius + 0.5f),
+                   kMaxSplatPointCount);
   for (int i = 0; i < splat_point_count; ++ i) {
     float factor = i / (splat_point_count - 1.0f);
-    Eigen::Vector3f point = endpoint1 + factor * endpoint_delta;
+    Eigen::Vector3f image_point = image_endpoint1 + factor * endpoint_delta;
     DrawEdgeSplatIfVisible(
-        splat_radius, camera, image_R_global, image_T_global, point, input, output);
+        splat_radius, camera, image_point, output);
   }
 }
 
 template<class Camera>
 void OcclusionGeometry::DrawEdgeSplatIfVisible(
-    int splat_radius,
+    float splat_radius,
     const Camera& camera,
-    const Eigen::Matrix3f& image_R_global,
-    const Eigen::Vector3f& image_T_global,
-    const Eigen::Vector3f& point,
-    const cv::Mat_<float>& /*input*/,
+    const Eigen::Vector3f& image_point,
     cv::Mat_<float>* output) const {
-  const float kOcclusionDepthThreshold = 0.01f;
-  
-  Eigen::Vector3f image_point = image_R_global * point + image_T_global;
+  const float kOcclusionDepthThreshold = 0.05f;
   if (image_point.z() > 0) {
-    Eigen::Vector2f ixy = camera.NormalizedToImage(Eigen::Vector2f(
+    Eigen::Vector2f pxy = camera.NormalizedToImage(Eigen::Vector2f(
         image_point.x() / image_point.z(), image_point.y() / image_point.z()));
-    int ix = ixy.x() + 0.5f;
-    int iy = ixy.y() + 0.5f;
-    if (ixy.x() + 0.5f >= 0 && ixy.y() + 0.5f >= 0 &&
+    int ix = pxy.x() + 0.5f;
+    int iy = pxy.y() + 0.5f;
+    if (pxy.x() + 0.5f >= 0 && pxy.y() + 0.5f >= 0 &&
         ix >= 0 && iy >= 0 &&
         ix < camera.width() && iy < camera.height() &&
         (*output)(iy, ix) + kOcclusionDepthThreshold >= image_point.z()) {
-      
-      // Draw splat.
-      int min_x = std::max(0, ix - splat_radius);
-      int min_y = std::max(0, iy - splat_radius);
-      int end_x = std::min(camera.width(), ix + splat_radius + 1);
-      int end_y = std::min(camera.height(), iy + splat_radius + 1);
+      Eigen::Matrix<float,2,3> dxy;
+      camera.ImageDerivativeByWorld(image_point, dxy);
+      Eigen::Vector2f splat_radius_px = dxy.rowwise().norm() * splat_radius;
+      int min_x = std::max(0, int(ix - splat_radius_px.x() + 0.5));
+      int min_y = std::max(0, int(iy - splat_radius_px.y() + 0.5));
+      int end_x = std::min(camera.width(), int(ix + splat_radius_px.x() + 1.5));
+      int end_y = std::min(camera.height(), int(iy + splat_radius_px.y() + 1.5));      
       for (int y = min_y; y < end_y; ++ y) {
         for (int x = min_x; x < end_x; ++ x) {
-          if ((*output)(y, x) > image_point.z()) {
+          float old_depth = (*output)(y, x);
+          if (old_depth == 0 || old_depth + kOcclusionDepthThreshold > image_point.z()) {
             (*output)(y, x) = -1;
           }
         }
       }
-      
     }
   }
 }
 
 template<class Camera>
 cv::Mat_<float> OcclusionGeometry::_RenderDepthMapWithSplatsCPU(
-    float splat_radius_factor,
     const Intrinsics& /*intrinsics*/,
     const Image& image,
     int /*image_scale*/,
     const Camera& image_scale_camera) const {
   constexpr bool kDebugShowDepthMaps = false;
   
-  const int splat_radius =
-      std::max<int>(1, image_scale_camera.width() * splat_radius_factor + 0.5f);
+  const float point_radius = GlobalParameters().splat_radius;
+  const float max_splat_radius = 10;
   
   cv::Mat_<float> splat_image(image_scale_camera.height(),
                               image_scale_camera.width());
@@ -372,14 +357,19 @@ cv::Mat_<float> OcclusionGeometry::_RenderDepthMapWithSplatsCPU(
     
     Eigen::Vector3f pp = image_R_global * point.getVector3fMap() + image_T_global;
     if (pp.z() > 0.f) {
-      Eigen::Vector2f ixy = image_scale_camera.NormalizedToImage(Eigen::Vector2f(pp.x() / pp.z(), pp.y() / pp.z()));
-      int ix = ixy.x() + 0.5f;
-      int iy = ixy.y() + 0.5f;
-      int min_x = std::max(0, ix - splat_radius);
-      int min_y = std::max(0, iy - splat_radius);
-      int end_x = std::min(splat_image.cols, ix + splat_radius + 1);
-      int end_y = std::min(splat_image.rows, iy + splat_radius + 1);
-      
+      Eigen::Vector2f pxy = image_scale_camera.NormalizedToImage(Eigen::Vector2f(pp.x() / pp.z(), pp.y() / pp.z()));
+      Eigen::Matrix<float,2,3> dxy;
+      image_scale_camera.ImageDerivativeByWorld(pp, dxy);
+      Eigen::Vector2f splat_radius = dxy.rowwise().norm() * point_radius;
+      splat_radius.x() = std::min(splat_radius.x(), max_splat_radius);
+      splat_radius.y() = std::min(splat_radius.y(), max_splat_radius);
+      int ix = pxy.x() + 0.5f;
+      int iy = pxy.y() + 0.5f;
+      int min_x = std::max(0, int(ix - splat_radius.x() + 0.5));
+      int min_y = std::max(0, int(iy - splat_radius.y() + 0.5));
+      int end_x = std::min(image_scale_camera.width(), int(ix + splat_radius.x() + 1.5));
+      int end_y = std::min(image_scale_camera.height(), int(iy + splat_radius.y() + 1.5));
+      if (min_y < end_y && min_x < end_x)
       for (int y = min_y; y < end_y; ++ y) {
         for (int x = min_x; x < end_x; ++ x) {
           if (splat_image(y, x) > pp.z()) {
@@ -399,43 +389,31 @@ cv::Mat_<float> OcclusionGeometry::_RenderDepthMapWithSplatsCPU(
   return splat_image;
 }
 
-void OcclusionGeometry::AddHalfEdge(
+void inline OcclusionGeometry::AddHalfEdge(
     uint32_t vertex1,
     uint32_t vertex2,
     uint32_t face_index,
-    std::unordered_map<IndexPair, std::size_t>* half_edge_map,
-    std::vector<EdgeWithFaces>* edges_with_faces) {
-  if (vertex1 > vertex2) {
+    HalfEdgeMap* half_edge_map) {
+  bool swap = vertex1 > vertex2;
+  if (swap)
     std::swap(vertex1, vertex2);
-  }
   
   IndexPair key = std::make_pair(vertex1, vertex2);
+  FaceWithSign vector_value = std::make_pair(face_index, swap);
   auto it = half_edge_map->find(key);
   if (it == half_edge_map->end()) {
     // The other face of this edge either does not exist or was not found yet.
     // Add the edge to the half edge map.
-    half_edge_map->insert(std::make_pair(key, face_index));
+    std::vector<FaceWithSign> face_vector(1, vector_value);
+    half_edge_map->insert(std::make_pair(key, face_vector));
   } else {
-    // The other face of this edge is already in the map. Output the edge with
-    // normals.
-    uint32_t other_face_index = it->second;
-    EdgeWithFaces new_edge;
-    new_edge.vertex_index1 = vertex1;
-    new_edge.vertex_index2 = vertex2;
-    new_edge.face_index1 = face_index;
-    new_edge.face_index2 = other_face_index;
-    edges_with_faces->push_back(new_edge);
-    
-    // It is not necessary to remove the half edge, but it is much faster than
-    // leaving it in.
-    half_edge_map->erase(it);
+    it->second.push_back(vector_value);
   }
 }
 
 void OcclusionGeometry::ComputeEdgeNormalsList(
     const pcl::PolygonMesh& mesh,
     EdgesWithFaceNormalsMesh* output) {
-  output->edges_with_faces.reserve(32000);
   output->vertices.reset(new pcl::PointCloud<pcl::PointXYZ>());
   pcl::fromPCLPointCloud2(mesh.cloud, *output->vertices);
   output->face_normals.resize(Eigen::NoChange, mesh.polygons.size());
@@ -444,26 +422,151 @@ void OcclusionGeometry::ComputeEdgeNormalsList(
   // Maps pairs of (smaller_vertex_index, larger_vertex_index) to the index of
   // the first adjacent face. If later the second face adjacent to an edge is
   // found, it is removed from this list.
-  std::unordered_map<IndexPair, std::size_t> half_edge_map;
+  HalfEdgeMap half_edge_map;
   half_edge_map.reserve(32000);
   
   for (std::size_t face_index = 0; face_index < mesh.polygons.size(); ++ face_index) {
     const pcl::Vertices& polygon_vertices = mesh.polygons.at(face_index);
-    const std::vector<uint32_t>& face_indices = polygon_vertices.vertices;
-    CHECK_EQ(face_indices.size(), 3);
+    const std::vector<uint32_t>& face_vertices = polygon_vertices.vertices;
+    CHECK_EQ(face_vertices.size(), 3);
+
     
     // Compute face normal.
-    Eigen::Vector3f a = output->vertices->at(face_indices[1]).getVector3fMap() -
-                        output->vertices->at(face_indices[0]).getVector3fMap();
-    Eigen::Vector3f b = output->vertices->at(face_indices[2]).getVector3fMap() -
-                        output->vertices->at(face_indices[0]).getVector3fMap();
+    Eigen::Vector3f a = output->vertices->at(face_vertices[1]).getVector3fMap() -
+                        output->vertices->at(face_vertices[0]).getVector3fMap();
+    Eigen::Vector3f b = output->vertices->at(face_vertices[2]).getVector3fMap() -
+                        output->vertices->at(face_vertices[0]).getVector3fMap();
     output->face_normals.col(face_index) = a.cross(b).normalized();
     
     // Add the face's half edges.
-    AddHalfEdge(face_indices[0], face_indices[1], face_index, &half_edge_map, &output->edges_with_faces);
-    AddHalfEdge(face_indices[1], face_indices[2], face_index, &half_edge_map, &output->edges_with_faces);
-    AddHalfEdge(face_indices[2], face_indices[0], face_index, &half_edge_map, &output->edges_with_faces);
+    AddHalfEdge(face_vertices[0], face_vertices[1], face_index, &half_edge_map);
+    AddHalfEdge(face_vertices[1], face_vertices[2], face_index, &half_edge_map);
+    AddHalfEdge(face_vertices[2], face_vertices[0], face_index, &half_edge_map);
   }
+  LOG(INFO) << "filtering edge list";
+  FilterEdgeList(&half_edge_map, output);
 }
 
+// Check that the edge is a genuine edge, i.e. every triangle is contained in the same hemisphere
+// And only keep the outer faces
+void OcclusionGeometry::FilterEdgeList(
+  HalfEdgeMap* half_edge_map,
+  EdgesWithFaceNormalsMesh* output) {
+  const pcl::PointCloud<pcl::PointXYZ>& vertices = *output->vertices;
+  const auto& face_normals = output->face_normals;
+  std::vector<EdgeWithFaces>& edges_with_faces = output->edges_with_faces;
+
+  #pragma omp parallel for shared(edges_with_faces, vertices, face_normals)
+  for(std::size_t b=0; b<half_edge_map->bucket_count();b++)
+  for (auto it = half_edge_map->begin(b); it!= half_edge_map->end(b); ++it){
+    constexpr float kEpsilon = 1e-4;
+    const auto& edge_vertices = it->first;
+    const auto& normal_vector = it->second;
+    std::size_t face_index1 = normal_vector.at(0).first;
+
+    // construct the edge that will be used to
+    // mask occlusion boundaries
+    EdgeWithFaces new_edge;
+    new_edge.vertex_index1 = edge_vertices.first;
+    new_edge.vertex_index2 = edge_vertices.second;
+    new_edge.face_index1 = face_index1;
+    if (normal_vector.size() == 1){
+      new_edge.face_index2 = std::numeric_limits<std::size_t>::max();
+      #pragma omp critical
+      edges_with_faces.push_back(new_edge);
+      continue;
+    }
+
+    const Eigen::Vector3f start_vertex = vertices.at(edge_vertices.first).getVector3fMap();
+    const Eigen::Vector3f end_vertex = vertices.at(edge_vertices.second).getVector3fMap();
+    const Eigen::Vector3f edge = (end_vertex - start_vertex);
+
+    
+    float factor1 = normal_vector.at(0).second ? -1.f : 1.f;
+    Eigen::Vector3f first_normal = face_normals.col(face_index1) * factor1;
+    
+    std::size_t face_index2 = normal_vector.at(1).first;
+    float factor2 = normal_vector.at(1).second ? -1.f : 1.f;
+    Eigen::Vector3f second_normal = face_normals.col(face_index2) * factor2;
+
+    new_edge.face_index2 = face_index2;
+    new_edge.opposite_normals = factor1 * factor2 > 0;
+
+    // We know all normals are normal to the edge, and thus are in the same plane.
+    // Project normals of the edge to the corresponding 2D base in order to keep
+    // the 2 outermost faces, or dismiss the edge altogether if the normals are
+    // not contained in a single hemisphere (ie a single hemi disk in the 2D case)
+    Eigen::Vector2f n1(1.f,0.f);
+    Eigen::Vector2f n2;
+
+    //base_x is also the first normal
+    const Eigen::Vector3f base_x = first_normal.normalized();
+    const Eigen::Vector3f base_y = base_x.cross(edge).normalized();
+    n2.x() = base_x.dot(second_normal);
+    n2.y() = base_y.dot(second_normal);
+    if(n2.x() < 0 && abs(n2.y()) < kEpsilon){
+      // The surface is actually a plane because n1 = -n2,
+      // Don't keep this edge
+      continue;
+    }
+
+    if(normal_vector.size() == 2){
+      // Simplest case : Edge has only two faces that are no coplanar,
+      // as it is always the case for e.g. meshes constructed with
+      // Poisson Reconstruction
+      #pragma omp critical
+      edges_with_faces.push_back(new_edge);
+      continue;
+    }
+
+    float cross_n1n2 = n2.y();
+    bool hemishpere = true;
+    const std::vector<FaceWithSign> remaining_normals(normal_vector.begin() + 2, normal_vector.end());
+    for(auto& face_id_with_sign : remaining_normals) {
+      // 2D algorithm to determine if all vectors are within the same hemi disk
+      // First vector is (1,0)
+      // Second vector is (base_x, base_y)
+      // The expected output is the two most distant face indexes, since we don't need
+      // the others to determine occlusion boundaries
+      const std::size_t face_index3 = face_id_with_sign.first;
+      const float factor3 = face_id_with_sign.second ? -1.f : 1.f;
+      Eigen::Vector3f current_normal = face_normals.col(face_index3) * factor3;
+      const Eigen::Vector2f n3(base_x.dot(current_normal), base_y.dot(current_normal));
+      const float cross_n1n3 = n1.x() * n3.y() - n1.y() * n3.x();
+      const float cross_n2n3 = n2.x() * n3.y() - n2.y() * n3.x();
+      // First case:
+      // If n1^n3 is the same sign of n1^n2 AND n2^n3 is the same sign of n2^n1
+      // (ie opposite sign of n1^n2)
+      // Then, n3 is between n1 and n2 : dismiss it and continue (ie do nothing)
+      // Second Case:
+      // If only n1^n3 is the same sign of n1^n2 then we are on the same
+      // hemi disk, but n3 is not between n1 and n2 : replace n2 by n3 and continue
+      // Third Case:
+      // reciprocally replace n1 by n3 if only n2^n3 is the same sign of n2^n1
+      // Fourth case:
+      // Dismiss the whole edge otherwise, the three vectors are not on the same hemi disk
+      const bool sign1 = cross_n1n3 * cross_n1n2 > 0; // Meaning n2 and n3 are the same side of n1
+      const bool sign2 = cross_n2n3 * cross_n1n2 < 0; // Meaning n1 and n3 are the same side of n2
+      if(sign1 && !sign2){
+        n2 = n3;
+        new_edge.face_index2 = face_index3;
+        factor2 = factor3;
+        new_edge.opposite_normals = factor1 * factor3 != 1;
+      }else if(sign2 && !sign1){
+        n1 = n3;
+        new_edge.face_index1 = face_index3;
+        factor1 = factor3;
+        new_edge.opposite_normals = factor3 * factor2 != 1;
+      }else if(!sign2 && !sign2){
+        hemishpere = false;
+        break;
+      }
+
+    }
+    if(hemishpere){
+      #pragma omp critical
+      edges_with_faces.push_back(new_edge);
+    }
+  }
+}
 }  // namespace opt

--- a/src/opt/occlusion_geometry.cc
+++ b/src/opt/occlusion_geometry.cc
@@ -415,7 +415,7 @@ cv::Mat_<float> OcclusionGeometry::_RenderDepthMapWithSplatsCPU(
     }
   }
   
-  Eigen::Matrix3f image_R_global = image.image_T_global.so3().matrix();
+  Eigen::Matrix3f image_R_global = image.image_T_global.rotationMatrix();
   Eigen::Vector3f image_T_global = image.image_T_global.translation();
   
   // Render points as splats to approximately determine visibility.

--- a/src/opt/occlusion_geometry.h
+++ b/src/opt/occlusion_geometry.h
@@ -35,15 +35,14 @@
 #include <pcl/point_types.h>
 #include <pcl/PolygonMesh.h>
 
+#include <boost/functional/hash.hpp>
+
 #include "base/util.h"
 #include "opengl/renderer.h"
 #include "opengl/mesh.h"
 #include "opengl/opengl_util.h"
 #include "opt/image.h"
 #include "opt/intrinsics.h"
-
-typedef std::pair<std::size_t, std::size_t> IndexPair;
-MAKE_HASHABLE(IndexPair, t.first, t.second)
 
 namespace opt {
 
@@ -66,18 +65,22 @@ class OcclusionGeometry {
       const opt::Intrinsics& intrinsics,
       const opt::Image& image,
       int image_scale,
-      bool mask_occlusion_boundaries = true,
-      float splat_radius_factor = 15.f / 6000.f,
       float min_depth = 0.05f,
-      float max_depth = 100.f) const;
+      float max_depth = 100.f,
+      bool mask_occlusion_boundaries = true) const;
   
  private:
   // Stores an edge and its two adjacent faces.
+  typedef std::pair<std::size_t, std::size_t> IndexPair;
+  typedef std::pair<std::size_t, bool> FaceWithSign;
+  typedef std::unordered_map<IndexPair, std::vector<FaceWithSign>, boost::hash<IndexPair>> HalfEdgeMap;
+
   struct EdgeWithFaces {
     std::size_t vertex_index1;
     std::size_t vertex_index2;
     std::size_t face_index1;
     std::size_t face_index2;
+    bool opposite_normals;
   };
   
   struct EdgesWithFaceNormalsMesh {
@@ -88,7 +91,6 @@ class OcclusionGeometry {
   
   template<class Camera>
   cv::Mat_<float> _RenderDepthMapWithSplatsCPU(
-      float splat_radius_factor,
       const Intrinsics& intrinsics,
       const Image& image,
       int image_scale,
@@ -98,16 +100,18 @@ class OcclusionGeometry {
       uint32_t vertex1,
       uint32_t vertex2,
       uint32_t face_index,
-      std::unordered_map<IndexPair, std::size_t>* half_edge_map,
-      std::vector<EdgeWithFaces>* edges_with_faces);
+      HalfEdgeMap* half_edge_map);
   
   void ComputeEdgeNormalsList(
       const pcl::PolygonMesh& mesh,
       EdgesWithFaceNormalsMesh* output);
+
+  void FilterEdgeList(
+      HalfEdgeMap* half_edge_map,
+      EdgesWithFaceNormalsMesh* output);
   
   template<class Camera>
   void MaskOutOcclusionBoundaries(
-      float splat_radius_factor,
       const Camera& camera,
       const Image& image,
       const cv::Mat_<float>& input,

--- a/src/opt/occlusion_geometry.h
+++ b/src/opt/occlusion_geometry.h
@@ -37,6 +37,8 @@
 
 #include <boost/functional/hash.hpp>
 
+#include <sophus/sim3.hpp>
+
 #include "base/util.h"
 #include "opengl/renderer.h"
 #include "opengl/mesh.h"

--- a/src/opt/parameters.h
+++ b/src/opt/parameters.h
@@ -59,6 +59,8 @@ struct Parameters {
     occlusion_depth_threshold = 0.01f;
     min_occlusion_depth = 0.05f;
     max_occlusion_depth = 100.f;
+
+    splat_radius = 0.03f; //3cm
     
     min_radius_bias = 1.05f;
     merge_distance_factor = 4.0f;
@@ -91,6 +93,8 @@ struct Parameters {
     pcl::console::parse_argument(argc, argv, "--occlusion_depth_threshold", occlusion_depth_threshold);
     pcl::console::parse_argument(argc, argv, "--max_occlusion_depth", max_occlusion_depth);
     pcl::console::parse_argument(argc, argv, "--min_occlusion_depth", min_occlusion_depth);
+
+    pcl::console::parse_argument(argc, argv, "--splat_radius", splat_radius);
     
     pcl::console::parse_argument(argc, argv, "--min_radius_bias", min_radius_bias);
     pcl::console::parse_argument(argc, argv, "--merge_distance_factor", merge_distance_factor);
@@ -114,6 +118,7 @@ struct Parameters {
     stream << "occlusion_depth_threshold " << occlusion_depth_threshold << std::endl;
     stream << "max_occlusion_depth" << max_occlusion_depth << std::endl;
     stream << "min_occlusion_depth" << min_occlusion_depth << std::endl;
+    stream << "splat_radius" << splat_radius << std::endl;
     stream << "min_radius_bias " << min_radius_bias << std::endl;
     stream << "merge_distance_factor " << merge_distance_factor << std::endl;
   }
@@ -190,6 +195,9 @@ struct Parameters {
   float min_occlusion_depth;
   // Max occlusion depth. Everything further than this will appear occluded
   float max_occlusion_depth;
+
+  // Radius of splats, used for depth renderings, and occlusion boundaries, in meters
+  float splat_radius;
   
   
   // ### For multi-scale point cloud ###

--- a/src/opt/parameters.h
+++ b/src/opt/parameters.h
@@ -57,6 +57,8 @@ struct Parameters {
     maximum_valid_intensity = 252;
     min_occlusion_check_image_scale = 0;
     occlusion_depth_threshold = 0.01f;
+    min_occlusion_depth = 0.05f;
+    max_occlusion_depth = 100.f;
     
     min_radius_bias = 1.05f;
     merge_distance_factor = 4.0f;
@@ -87,6 +89,8 @@ struct Parameters {
     pcl::console::parse_argument(argc, argv, "--maximum_valid_intensity", maximum_valid_intensity);
     pcl::console::parse_argument(argc, argv, "--min_occlusion_check_image_scale", min_occlusion_check_image_scale);
     pcl::console::parse_argument(argc, argv, "--occlusion_depth_threshold", occlusion_depth_threshold);
+    pcl::console::parse_argument(argc, argv, "--max_occlusion_depth", max_occlusion_depth);
+    pcl::console::parse_argument(argc, argv, "--min_occlusion_depth", min_occlusion_depth);
     
     pcl::console::parse_argument(argc, argv, "--min_radius_bias", min_radius_bias);
     pcl::console::parse_argument(argc, argv, "--merge_distance_factor", merge_distance_factor);
@@ -108,6 +112,8 @@ struct Parameters {
     stream << "maximum_valid_intensity " << maximum_valid_intensity << std::endl;
     stream << "min_occlusion_check_image_scale " << min_occlusion_check_image_scale << std::endl;
     stream << "occlusion_depth_threshold " << occlusion_depth_threshold << std::endl;
+    stream << "max_occlusion_depth" << max_occlusion_depth << std::endl;
+    stream << "min_occlusion_depth" << min_occlusion_depth << std::endl;
     stream << "min_radius_bias " << min_radius_bias << std::endl;
     stream << "merge_distance_factor " << merge_distance_factor << std::endl;
   }
@@ -175,6 +181,15 @@ struct Parameters {
   // The depth by which a point can lie behind its corresponding pixel in a
   // depth map while still being considered as visible.
   float occlusion_depth_threshold;
+
+
+  // ### Occlusion distance limits
+  // don't use values too further appart as it will degrade occlusion depth precision
+  // because opengl depth buffer normalizes everything to fit [0,1]
+  //Min occlusion depth. Everything closer will appear not occluded
+  float min_occlusion_depth;
+  // Max occlusion depth. Everything further than this will appear occluded
+  float max_occlusion_depth;
   
   
   // ### For multi-scale point cloud ###

--- a/src/opt/problem.h
+++ b/src/opt/problem.h
@@ -138,7 +138,8 @@ class Problem {
   
   // Performs only the first part of SetScanGeometryAndInitialize(): Initializes
   // image scales and loads the images.
-  void InitializeImages(const std::string& image_base_path);
+  void InitializeImages();
+  void LoadImages(const std::string& image_base_path);
   
   // Removes all rigs, rig images and rig assignments.
   void RemoveRigs();

--- a/src/opt/test/test_interpolation.cc
+++ b/src/opt/test/test_interpolation.cc
@@ -38,7 +38,7 @@ constexpr float kErrorEpsilon = 1e-5f;
 
 TEST(Interpolation, Bilinear) {
   cv::Mat_<float> image(2, 2);
-  float value, dvalue_dx, dvalue_dy;
+  float value=0, dvalue_dx = 0, dvalue_dy = 0;
   
   // Setup image.
   image(0, 0) = 1;

--- a/src/opt/test/test_renderer.cc
+++ b/src/opt/test/test_renderer.cc
@@ -233,8 +233,8 @@ TEST(Renderer, PixelAccuracy_Polynomial) {
 }
 
 TEST(Renderer, PixelAccuracy_Radial) {
-  camera::RadialCamera radial_camera(kImageWidth, kImageHeight, kFX,
-                                             kFY, kCX, kCY, kK1, -kK2);
+  camera::RadialCamera radial_camera(kImageWidth, kImageHeight,
+                                     kFX, kCX, kCY, kK1, -kK2);
   TestRendererPixelAccuracy(radial_camera);
 }
 
@@ -245,14 +245,14 @@ TEST(Renderer, PixelAccuracy_SimpleRadial) {
 }
 
 TEST(Renderer, PixelAccuracy_RadialFisheye) {
-  camera::RadialFisheyeCamera radial_fisheye_camera(kImageWidth, kImageHeight, kFX,
-                                             kFY, kCX, kCY, 0.221184, 0.128597);
+  camera::RadialFisheyeCamera radial_fisheye_camera(kImageWidth, kImageHeight,
+                                             kFX, kCX, kCY, 0.221184, 0.128597);
   TestRendererPixelAccuracy(radial_fisheye_camera);
 }
 
 TEST(Renderer, PixelAccuracy_SimpleRadialFisheye) {
   camera::SimpleRadialFisheyeCamera simple_radial_fisheye_camera(kImageWidth, kImageHeight,
-                                                          kFX, kCX, kCY, 0.221184);
+                                                          0.5*kFX, kCX, kCY, kK1);
   TestRendererPixelAccuracy(simple_radial_fisheye_camera);
 }
 

--- a/src/opt/visibility_estimator.cc
+++ b/src/opt/visibility_estimator.cc
@@ -66,7 +66,9 @@ void VisibilityEstimator::AppendObservationsForImage(
   const camera::CameraBase& camera_base =
       *intrinsics.model(best_available_image_scale);
   cv::Mat_<float> occlusion_image = problem_->occlusion_geometry().RenderDepthMap(
-      intrinsics, image, best_available_image_scale);
+      intrinsics, image, best_available_image_scale,
+      opt::GlobalParameters().min_occlusion_depth,
+      opt::GlobalParameters().max_occlusion_depth);
   
   observations->resize(problem_->point_scale_count());
   bool had_many_observations = false;
@@ -99,7 +101,9 @@ void VisibilityEstimator::AppendObservationsForImage(
   int best_available_image_scale =
       intrinsics.best_available_image_scale(std::max(GlobalParameters().min_occlusion_check_image_scale, problem_->current_image_scale()));
   cv::Mat_<float> occlusion_image = occlusion_geometry.RenderDepthMap(
-      intrinsics, image, best_available_image_scale);
+      intrinsics, image, best_available_image_scale,
+      opt::GlobalParameters().min_occlusion_depth,
+      opt::GlobalParameters().max_occlusion_depth);
   
   const camera::CameraBase& camera_base =
       *intrinsics.model(best_available_image_scale);
@@ -120,7 +124,9 @@ void VisibilityEstimator::AppendObservationsForImageNoScale(
   int best_available_image_scale =
       intrinsics.best_available_image_scale(std::max(GlobalParameters().min_occlusion_check_image_scale, problem_->current_image_scale()));
   cv::Mat_<float> occlusion_image = occlusion_geometry.RenderDepthMap(
-      intrinsics, image, best_available_image_scale);
+      intrinsics, image, best_available_image_scale,
+      opt::GlobalParameters().min_occlusion_depth,
+      opt::GlobalParameters().max_occlusion_depth);
   
   const camera::CameraBase& camera_base =
       *intrinsics.model(best_available_image_scale);

--- a/src/point_cloud_editor/csg_operation.cc
+++ b/src/point_cloud_editor/csg_operation.cc
@@ -31,7 +31,7 @@
 
 #include <cork.h>
 #include <QMessageBox>
-#include <sophus/se3.hpp>
+#include <sophus/sim3.hpp>
 
 #include "point_cloud_editor/object.h"
 #include "point_cloud_editor/util.h"
@@ -74,7 +74,7 @@ void PerformCSGOperation(Scene* scene, CSGOperation operation, bool operate_on_s
   if (operate_on_submesh_of_2nd_mesh) {
     // Determine the bounding box of the second mesh in the first mesh's space.
     Eigen::AlignedBox3f mesh_bbox;
-    Sophus::SE3f first_TR_second = first_object->global_T_object.inverse() * second_object->global_T_object;
+    Sophus::Sim3f first_TR_second = first_object->global_T_object.inverse() * second_object->global_T_object;
     Eigen::Matrix3f first_R_second = first_TR_second.rotationMatrix();
     Eigen::Vector3f first_T_second = first_TR_second.translation();
     for (std::size_t i = 0; i < second_object->cloud->size(); ++ i) {

--- a/src/point_cloud_editor/object.h
+++ b/src/point_cloud_editor/object.h
@@ -35,7 +35,7 @@
 #include <cork.h>
 #include <GL/glew.h>
 #include <GL/gl.h>
-#include <sophus/se3.hpp>
+#include <sophus/sim3.hpp>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/PolygonMesh.h>
@@ -137,7 +137,7 @@ struct Object {
   bool is_modified;
   
   // Transformation from the object frame to the global frame.
-  Sophus::SE3f global_T_object;
+  Sophus::Sim3f global_T_object;
   
   // Vertex and color data in CPU memory.
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud;

--- a/src/point_cloud_editor/tool_csg.cc
+++ b/src/point_cloud_editor/tool_csg.cc
@@ -140,7 +140,7 @@ bool CSGTool::mouseMoveEvent(QMouseEvent* event) {
     Eigen::Vector3f look_direction = (render_widget_->camera_look_at() - render_widget_->camera_position()).normalized();
     Eigen::Vector3f rotation_axis = object_.global_T_object.rotationMatrix().transpose() * look_direction;
     Eigen::AngleAxisf rotation(rotation_angle, rotation_axis);
-    object_.global_T_object = object_.global_T_object * Sophus::SE3f(rotation.toRotationMatrix(), Eigen::Vector3f(0, 0, 0));
+    object_.global_T_object = object_.global_T_object * Sophus::Sim3f(Sophus::RxSO3f(rotation.toRotationMatrix()), Eigen::Vector3f(0, 0, 0));
     
     render_widget_->update(render_widget_->rect());
   } else if (move_mode_ == MoveMode::kScale) {

--- a/src/point_cloud_editor/tool_select_beyond_plane.cc
+++ b/src/point_cloud_editor/tool_select_beyond_plane.cc
@@ -56,7 +56,7 @@ void BeyondPlaneSelectionTool::PerformSelection(
   // where the camera position is.
   int current_object_index = render_widget_->current_object_index();
   const Object& selected_object = scene->object(current_object_index);
-  Sophus::SE3f object_T_global = selected_object.global_T_object.inverse();
+  Sophus::Sim3f object_T_global = selected_object.global_T_object.inverse();
   Eigen::Vector3f object_camera_position = object_T_global * render_widget_->camera_T_world().inverse().translation();
   if (plane.signedDistance(object_camera_position) < 0) {
     plane.coeffs() = -1 * plane.coeffs();
@@ -65,11 +65,11 @@ void BeyondPlaneSelectionTool::PerformSelection(
   // Select all points with negative distances. Optionally, limit the selection
   // to points which project into the camera image.
   const pcl::PointCloud<pcl::PointXYZRGB>& cloud = *selected_object.cloud;
-  Sophus::SE3f camera_RT_object =
-      render_widget_->camera_T_world() *
-      selected_object.global_T_object;
-  Eigen::Matrix3f camera_R_object = camera_RT_object.so3().matrix();
-  Eigen::Vector3f camera_T_object = camera_RT_object.translation();
+  Sophus::Sim3f camera_RsT_object(
+      render_widget_->camera_T_world().matrix() *
+      selected_object.global_T_object.matrix());
+  Eigen::Matrix3f camera_Rs_object = camera_RsT_object.rxso3().matrix();
+  Eigen::Vector3f camera_T_object = camera_RsT_object.translation();
   camera::PinholeCamera render_camera = render_widget_->render_camera();
   float max_depth = render_widget_->max_depth();
   float min_depth = render_widget_->min_depth();
@@ -82,7 +82,7 @@ void BeyondPlaneSelectionTool::PerformSelection(
     }
     
     if (limit_selection_to_visible_) {
-      Eigen::Vector3f camera_point = camera_R_object * point + camera_T_object;
+      Eigen::Vector3f camera_point = camera_Rs_object * point + camera_T_object;
       if (camera_point.z() >= min_depth && camera_point.z() <= max_depth) {
         Eigen::Vector2f pxy = render_camera.NormalizedToImage(Eigen::Vector2f(
             camera_point.x() / camera_point.z(), camera_point.y() / camera_point.z()));
@@ -113,11 +113,11 @@ bool BeyondPlaneSelectionTool::mousePressEvent(QMouseEvent* event) {
     int current_object_index = render_widget_->current_object_index();
     const Object& object_struct = scene->object(current_object_index);
     const pcl::PointCloud<pcl::PointXYZRGB>& cloud = *object_struct.cloud;
-    Sophus::SE3f camera_RT_object =
-        render_widget_->camera_T_world() *
-        object_struct.global_T_object;
-    Eigen::Matrix3f camera_R_object = camera_RT_object.so3().matrix();
-    Eigen::Vector3f camera_T_object = camera_RT_object.translation();
+    Sophus::Sim3f camera_RsT_object(
+        render_widget_->camera_T_world().matrix() *
+        object_struct.global_T_object.matrix());
+    Eigen::Matrix3f camera_Rs_object = camera_RsT_object.rxso3().matrix();
+    Eigen::Vector3f camera_T_object = camera_RsT_object.translation();
     camera::PinholeCamera render_camera = render_widget_->render_camera();
     float max_depth = render_widget_->max_depth();
     float min_depth = render_widget_->min_depth();
@@ -125,7 +125,7 @@ bool BeyondPlaneSelectionTool::mousePressEvent(QMouseEvent* event) {
     float best_distance = std::numeric_limits<float>::infinity();
     std::size_t best_point_index = 0;
     for (std::size_t point_index = 0, size = cloud.size(); point_index < size; ++ point_index) {
-      Eigen::Vector3f camera_point = camera_R_object * cloud.at(point_index).getVector3fMap() + camera_T_object;
+      Eigen::Vector3f camera_point = camera_Rs_object * cloud.at(point_index).getVector3fMap() + camera_T_object;
       if (camera_point.z() >= min_depth && camera_point.z() <= max_depth) {
         Eigen::Vector2f pxy = render_camera.NormalizedToImage(Eigen::Vector2f(
             camera_point.x() / camera_point.z(), camera_point.y() / camera_point.z()));
@@ -192,17 +192,17 @@ void BeyondPlaneSelectionTool::paintEvent(QPainter* qpainter) {
   Scene* scene = render_widget_->scene();
   int current_object_index = render_widget_->current_object_index();
   const Object& object_struct = scene->object(current_object_index);
-  Sophus::SE3f camera_RT_object =
-      render_widget_->camera_T_world() *
-      object_struct.global_T_object;
-  Eigen::Matrix3f camera_R_object = camera_RT_object.so3().matrix();
-  Eigen::Vector3f camera_T_object = camera_RT_object.translation();
+  Sophus::Sim3f camera_RsT_object(
+      render_widget_->camera_T_world().matrix() *
+      object_struct.global_T_object.matrix());
+  Eigen::Matrix3f camera_Rs_object = camera_RsT_object.rxso3().matrix();
+  Eigen::Vector3f camera_T_object = camera_RsT_object.translation();
   camera::PinholeCamera render_camera = render_widget_->render_camera();
   float max_depth = render_widget_->max_depth();
   float min_depth = render_widget_->min_depth();
   for (const Eigen::Vector3f& point : points_) {
     // Project to display.
-    Eigen::Vector3f camera_point = camera_R_object * point + camera_T_object;
+    Eigen::Vector3f camera_point = camera_Rs_object * point + camera_T_object;
     if (camera_point.z() >= min_depth && camera_point.z() <= max_depth) {
       Eigen::Vector2f pxy = render_camera.NormalizedToImage(Eigen::Vector2f(
           camera_point.x() / camera_point.z(), camera_point.y() / camera_point.z()));

--- a/thirdparty/sophus/average.hpp
+++ b/thirdparty/sophus/average.hpp
@@ -1,0 +1,231 @@
+/// @file
+/// Calculation of biinvariant means.
+
+#ifndef SOPHUS_AVERAGE_HPP
+#define SOPHUS_AVERAGE_HPP
+
+#include "common.hpp"
+#include "rxso2.hpp"
+#include "rxso3.hpp"
+#include "se2.hpp"
+#include "se3.hpp"
+#include "sim2.hpp"
+#include "sim3.hpp"
+#include "so2.hpp"
+#include "so3.hpp"
+
+namespace Sophus {
+
+/// Calculates mean iteratively.
+///
+/// Returns ``nullopt`` if it does not converge.
+///
+template <class SequenceContainer>
+optional<typename SequenceContainer::value_type> iterativeMean(
+    SequenceContainer const& foo_Ts_bar, int max_num_iterations) {
+  size_t N = foo_Ts_bar.size();
+  SOPHUS_ENSURE(N >= 1, "N must be >= 1.");
+
+  using Group = typename SequenceContainer::value_type;
+  using Scalar = typename Group::Scalar;
+  using Tangent = typename Group::Tangent;
+
+  // This implements the algorithm in the beginning of Sec. 4.2 in
+  // ftp://ftp-sop.inria.fr/epidaure/Publications/Arsigny/arsigny_rr_biinvariant_average.pdf.
+  Group foo_T_average = foo_Ts_bar.front();
+  Scalar w = Scalar(1. / N);
+  for (int i = 0; i < max_num_iterations; ++i) {
+    Tangent average;
+    setToZero<Tangent>(average);
+    for (Group const& foo_T_bar : foo_Ts_bar) {
+      average += w * (foo_T_average.inverse() * foo_T_bar).log();
+    }
+    Group foo_T_newaverage = foo_T_average * Group::exp(average);
+    if (squaredNorm<Tangent>(
+            (foo_T_newaverage.inverse() * foo_T_average).log()) <
+        Constants<Scalar>::epsilon()) {
+      return foo_T_newaverage;
+    }
+
+    foo_T_average = foo_T_newaverage;
+  }
+  // LCOV_EXCL_START
+  return nullopt;
+  // LCOV_EXCL_STOP
+}
+
+#ifdef DOXYGEN_SHOULD_SKIP_THIS
+/// Mean implementation for any Lie group.
+template <class SequenceContainer, class Scalar>
+optional<typename SequenceContainer::value_type> average(
+    SequenceContainer const& foo_Ts_bar);
+#else
+
+// Mean implementation for SO(2).
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+enable_if_t<
+    std::is_same<typename SequenceContainer::value_type, SO2<Scalar> >::value,
+    optional<typename SequenceContainer::value_type> >
+average(SequenceContainer const& foo_Ts_bar) {
+  // This implements rotational part of Proposition 12 from Sec. 6.2 of
+  // ftp://ftp-sop.inria.fr/epidaure/Publications/Arsigny/arsigny_rr_biinvariant_average.pdf.
+  size_t N = std::distance(std::begin(foo_Ts_bar), std::end(foo_Ts_bar));
+  SOPHUS_ENSURE(N >= 1, "N must be >= 1.");
+  SO2<Scalar> foo_T_average = foo_Ts_bar.front();
+  Scalar w = Scalar(1. / N);
+
+  Scalar average(0);
+  for (SO2<Scalar> const& foo_T_bar : foo_Ts_bar) {
+    average += w * (foo_T_average.inverse() * foo_T_bar).log();
+  }
+  return foo_T_average * SO2<Scalar>::exp(average);
+}
+
+// Mean implementation for RxSO(2).
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+enable_if_t<
+    std::is_same<typename SequenceContainer::value_type, RxSO2<Scalar> >::value,
+    optional<typename SequenceContainer::value_type> >
+average(SequenceContainer const& foo_Ts_bar) {
+  size_t N = std::distance(std::begin(foo_Ts_bar), std::end(foo_Ts_bar));
+  SOPHUS_ENSURE(N >= 1, "N must be >= 1.");
+  RxSO2<Scalar> foo_T_average = foo_Ts_bar.front();
+  Scalar w = Scalar(1. / N);
+
+  Vector2<Scalar> average(Scalar(0), Scalar(0));
+  for (RxSO2<Scalar> const& foo_T_bar : foo_Ts_bar) {
+    average += w * (foo_T_average.inverse() * foo_T_bar).log();
+  }
+  return foo_T_average * RxSO2<Scalar>::exp(average);
+}
+
+namespace details {
+template <class T>
+void getQuaternion(T const&);
+
+template <class Scalar>
+Eigen::Quaternion<Scalar> getUnitQuaternion(SO3<Scalar> const& R) {
+  return R.unit_quaternion();
+}
+
+template <class Scalar>
+Eigen::Quaternion<Scalar> getUnitQuaternion(RxSO3<Scalar> const& sR) {
+  return sR.so3().unit_quaternion();
+}
+
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+Eigen::Quaternion<Scalar> averageUnitQuaternion(
+    SequenceContainer const& foo_Ts_bar) {
+  // This:  http://stackoverflow.com/a/27410865/1221742
+  size_t N = std::distance(std::begin(foo_Ts_bar), std::end(foo_Ts_bar));
+  SOPHUS_ENSURE(N >= 1, "N must be >= 1.");
+  Eigen::Matrix<Scalar, 4, Eigen::Dynamic> Q(4, N);
+  int i = 0;
+  Scalar w = Scalar(1. / N);
+  for (auto const& foo_T_bar : foo_Ts_bar) {
+    Q.col(i) = w * details::getUnitQuaternion(foo_T_bar).coeffs();
+    ++i;
+  }
+
+  Eigen::Matrix<Scalar, 4, 4> QQt = Q * Q.transpose();
+  // TODO: Figure out why we can't use SelfAdjointEigenSolver here.
+  Eigen::EigenSolver<Eigen::Matrix<Scalar, 4, 4> > es(QQt);
+
+  std::complex<Scalar> max_eigenvalue = es.eigenvalues()[0];
+  Eigen::Matrix<std::complex<Scalar>, 4, 1> max_eigenvector =
+      es.eigenvectors().col(0);
+
+  for (int i = 1; i < 4; i++) {
+    if (std::norm(es.eigenvalues()[i]) > std::norm(max_eigenvalue)) {
+      max_eigenvalue = es.eigenvalues()[i];
+      max_eigenvector = es.eigenvectors().col(i);
+    }
+  }
+  Eigen::Quaternion<Scalar> quat;
+  quat.coeffs() <<                //
+      max_eigenvector[0].real(),  //
+      max_eigenvector[1].real(),  //
+      max_eigenvector[2].real(),  //
+      max_eigenvector[3].real();
+  return quat;
+}
+}  // namespace details
+
+// Mean implementation for SO(3).
+//
+// TODO: Detect degenerated cases and return nullopt.
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+enable_if_t<
+    std::is_same<typename SequenceContainer::value_type, SO3<Scalar> >::value,
+    optional<typename SequenceContainer::value_type> >
+average(SequenceContainer const& foo_Ts_bar) {
+  return SO3<Scalar>(details::averageUnitQuaternion(foo_Ts_bar));
+}
+
+// Mean implementation for R x SO(3).
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+enable_if_t<
+    std::is_same<typename SequenceContainer::value_type, RxSO3<Scalar> >::value,
+    optional<typename SequenceContainer::value_type> >
+average(SequenceContainer const& foo_Ts_bar) {
+  size_t N = std::distance(std::begin(foo_Ts_bar), std::end(foo_Ts_bar));
+
+  SOPHUS_ENSURE(N >= 1, "N must be >= 1.");
+  Scalar scale_sum = Scalar(0);
+  using std::exp;
+  using std::log;
+  for (RxSO3<Scalar> const& foo_T_bar : foo_Ts_bar) {
+    scale_sum += log(foo_T_bar.scale());
+  }
+  return RxSO3<Scalar>(exp(scale_sum / Scalar(N)),
+                       SO3<Scalar>(details::averageUnitQuaternion(foo_Ts_bar)));
+}
+
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+enable_if_t<
+    std::is_same<typename SequenceContainer::value_type, SE2<Scalar> >::value,
+    optional<typename SequenceContainer::value_type> >
+average(SequenceContainer const& foo_Ts_bar, int max_num_iterations = 20) {
+  // TODO: Implement Proposition 12 from Sec. 6.2 of
+  // ftp://ftp-sop.inria.fr/epidaure/Publications/Arsigny/arsigny_rr_biinvariant_average.pdf.
+  return iterativeMean(foo_Ts_bar, max_num_iterations);
+}
+
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+enable_if_t<
+    std::is_same<typename SequenceContainer::value_type, Sim2<Scalar> >::value,
+    optional<typename SequenceContainer::value_type> >
+average(SequenceContainer const& foo_Ts_bar, int max_num_iterations = 20) {
+  return iterativeMean(foo_Ts_bar, max_num_iterations);
+}
+
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+enable_if_t<
+    std::is_same<typename SequenceContainer::value_type, SE3<Scalar> >::value,
+    optional<typename SequenceContainer::value_type> >
+average(SequenceContainer const& foo_Ts_bar, int max_num_iterations = 20) {
+  return iterativeMean(foo_Ts_bar, max_num_iterations);
+}
+
+template <class SequenceContainer,
+          class Scalar = typename SequenceContainer::value_type::Scalar>
+enable_if_t<
+    std::is_same<typename SequenceContainer::value_type, Sim3<Scalar> >::value,
+    optional<typename SequenceContainer::value_type> >
+average(SequenceContainer const& foo_Ts_bar, int max_num_iterations = 20) {
+  return iterativeMean(foo_Ts_bar, max_num_iterations);
+}
+
+#endif  // DOXYGEN_SHOULD_SKIP_THIS
+
+}  // namespace Sophus
+
+#endif  // SOPHUS_AVERAGE_HPP

--- a/thirdparty/sophus/common.hpp
+++ b/thirdparty/sophus/common.hpp
@@ -1,0 +1,195 @@
+/// @file
+/// Common functionality.
+
+#ifndef SOPHUS_COMMON_HPP
+#define SOPHUS_COMMON_HPP
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <type_traits>
+
+#include <Eigen/Core>
+
+#if !defined(SOPHUS_DISABLE_ENSURES)
+#include "formatstring.hpp"
+#endif //!defined(SOPHUS_DISABLE_ENSURES)
+
+// following boost's assert.hpp
+#undef SOPHUS_ENSURE
+
+// ENSURES are similar to ASSERTS, but they are always checked for (including in
+// release builds). At the moment there are no ASSERTS in Sophus which should
+// only be used for checks which are performance critical.
+
+#ifdef __GNUC__
+#define SOPHUS_FUNCTION __PRETTY_FUNCTION__
+#elif (_MSC_VER >= 1310)
+#define SOPHUS_FUNCTION __FUNCTION__
+#else
+#define SOPHUS_FUNCTION "unknown"
+#endif
+
+// Make sure this compiles with older versions of Eigen which do not have
+// EIGEN_DEVICE_FUNC defined.
+#ifndef EIGEN_DEVICE_FUNC
+#define EIGEN_DEVICE_FUNC
+#endif
+
+// Make sure this compiles with older versions of Eigen which do not have
+// EIGEN_DEFAULT_COPY_CONSTRUCTOR defined
+#ifndef EIGEN_DEFAULT_COPY_CONSTRUCTOR
+#if EIGEN_HAS_CXX11
+#define EIGEN_DEFAULT_COPY_CONSTRUCTOR(CLASS) EIGEN_DEVICE_FUNC CLASS(const CLASS&) = default;
+#else
+#define EIGEN_DEFAULT_COPY_CONSTRUCTOR(CLASS)
+#endif
+#ifndef EIGEN_INHERIT_ASSIGNMENT_OPERATORS
+#error "eigen must have EIGEN_INHERIT_ASSIGNMENT_OPERATORS"
+#endif
+#define SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Derived) \
+    EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Derived) \
+    EIGEN_DEFAULT_COPY_CONSTRUCTOR(Derived)
+#endif
+
+#ifndef SOPHUS_INHERIT_ASSIGNMENT_OPERATORS
+#ifndef EIGEN_INHERIT_ASSIGNMENT_OPERATORS
+#error "eigen must have EIGEN_INHERIT_ASSIGNMENT_OPERATORS"
+#endif
+#define SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Derived) EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Derived)
+#endif
+
+#define SOPHUS_FUNC EIGEN_DEVICE_FUNC
+
+#if defined(SOPHUS_DISABLE_ENSURES)
+
+#define SOPHUS_ENSURE(expr, ...) ((void)0)
+
+#elif defined(SOPHUS_ENABLE_ENSURE_HANDLER)
+
+namespace Sophus {
+void ensureFailed(char const* function, char const* file, int line,
+                  char const* description);
+}
+
+#define SOPHUS_ENSURE(expr, ...)                     \
+  ((expr) ? ((void)0)                                \
+          : ::Sophus::ensureFailed(                  \
+                SOPHUS_FUNCTION, __FILE__, __LINE__, \
+                Sophus::details::FormatString(__VA_ARGS__).c_str()))
+#else
+// LCOV_EXCL_START
+
+namespace Sophus {
+template <class... Args>
+SOPHUS_FUNC void defaultEnsure(char const* function, char const* file, int line,
+                               char const* description, Args&&... args) {
+  std::printf("Sophus ensure failed in function '%s', file '%s', line %d.\n",
+              function, file, line);
+#ifdef __CUDACC__
+  std::printf("%s", description);
+#else
+  std::cout << details::FormatString(description, std::forward<Args>(args)...)
+            << std::endl;
+  std::abort();
+#endif
+}
+}  // namespace Sophus
+
+// LCOV_EXCL_STOP
+#define SOPHUS_ENSURE(expr, ...)                                       \
+  ((expr) ? ((void)0)                                                  \
+          : Sophus::defaultEnsure(SOPHUS_FUNCTION, __FILE__, __LINE__, \
+                                  ##__VA_ARGS__))
+#endif
+
+namespace Sophus {
+
+template <class Scalar>
+struct Constants {
+  SOPHUS_FUNC static Scalar epsilon() { return Scalar(1e-10); }
+
+  SOPHUS_FUNC static Scalar epsilonSqrt() {
+    using std::sqrt;
+    return sqrt(epsilon());
+  }
+
+  SOPHUS_FUNC static Scalar pi() {
+    return Scalar(3.141592653589793238462643383279502884);
+  }
+};
+
+template <>
+struct Constants<float> {
+  SOPHUS_FUNC static float constexpr epsilon() {
+    return static_cast<float>(1e-5);
+  }
+
+  SOPHUS_FUNC static float epsilonSqrt() { return std::sqrt(epsilon()); }
+
+  SOPHUS_FUNC static float constexpr pi() {
+    return 3.141592653589793238462643383279502884f;
+  }
+};
+
+/// Nullopt type of lightweight optional class.
+struct nullopt_t {
+  explicit constexpr nullopt_t() {}
+};
+
+constexpr nullopt_t nullopt{};
+
+/// Lightweight optional implementation which requires ``T`` to have a
+/// default constructor.
+///
+/// TODO: Replace with std::optional once Sophus moves to c++17.
+///
+template <class T>
+class optional {
+ public:
+  optional() : is_valid_(false) {}
+
+  optional(nullopt_t) : is_valid_(false) {}
+
+  optional(T const& type) : type_(type), is_valid_(true) {}
+
+  explicit operator bool() const { return is_valid_; }
+
+  T const* operator->() const {
+    SOPHUS_ENSURE(is_valid_, "must be valid");
+    return &type_;
+  }
+
+  T* operator->() {
+    SOPHUS_ENSURE(is_valid_, "must be valid");
+    return &type_;
+  }
+
+  T const& operator*() const {
+    SOPHUS_ENSURE(is_valid_, "must be valid");
+    return type_;
+  }
+
+  T& operator*() {
+    SOPHUS_ENSURE(is_valid_, "must be valid");
+    return type_;
+  }
+
+ private:
+  T type_;
+  bool is_valid_;
+};
+
+template <bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+template <class G>
+struct IsUniformRandomBitGenerator {
+  static const bool value = std::is_unsigned<typename G::result_type>::value &&
+                            std::is_unsigned<decltype(G::min())>::value &&
+                            std::is_unsigned<decltype(G::max())>::value;
+};
+}  // namespace Sophus
+
+#endif  // SOPHUS_COMMON_HPP

--- a/thirdparty/sophus/example_ensure_handler.cpp
+++ b/thirdparty/sophus/example_ensure_handler.cpp
@@ -1,0 +1,14 @@
+#include "common.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace Sophus {
+void ensureFailed(char const* function, char const* file, int line,
+                  char const* description) {
+  std::printf("Sophus ensure failed in function '%s', file '%s', line %d.\n",
+              file, function, line);
+  std::printf("Description: %s\n", description);
+  std::abort();
+}
+}  // namespace Sophus

--- a/thirdparty/sophus/formatstring.hpp
+++ b/thirdparty/sophus/formatstring.hpp
@@ -1,0 +1,72 @@
+/// @file
+/// FormatString functionality
+
+#ifndef SOPHUS_FORMATSTRING_HPP
+#define SOPHUS_FORMATSTRING_HPP
+
+#include <iostream>
+
+namespace Sophus {
+namespace details {
+
+// Following: http://stackoverflow.com/a/22759544
+template <class T>
+class IsStreamable {
+ private:
+  template <class TT>
+  static auto test(int)
+      -> decltype(std::declval<std::stringstream&>() << std::declval<TT>(),
+                  std::true_type());
+
+  template <class>
+  static auto test(...) -> std::false_type;
+
+ public:
+  static bool const value = decltype(test<T>(0))::value;
+};
+
+template <class T>
+class ArgToStream {
+ public:
+  static void impl(std::stringstream& stream, T&& arg) {
+    stream << std::forward<T>(arg);
+  }
+};
+
+inline void FormatStream(std::stringstream& stream, char const* text) {
+  stream << text;
+  return;
+}
+
+// Following: http://en.cppreference.com/w/cpp/language/parameter_pack
+template <class T, typename... Args>
+void FormatStream(std::stringstream& stream, char const* text, T&& arg,
+                  Args&&... args) {
+  static_assert(IsStreamable<T>::value,
+                "One of the args has no ostream overload!");
+  for (; *text != '\0'; ++text) {
+    if (*text == '%') {
+      ArgToStream<T&&>::impl(stream, std::forward<T>(arg));
+      FormatStream(stream, text + 1, std::forward<Args>(args)...);
+      return;
+    }
+    stream << *text;
+  }
+  stream << "\nFormat-Warning: There are " << sizeof...(Args) + 1
+         << " args unused.";
+  return;
+}
+
+template <class... Args>
+std::string FormatString(char const* text, Args&&... args) {
+  std::stringstream stream;
+  FormatStream(stream, text, std::forward<Args>(args)...);
+  return stream.str();
+}
+
+inline std::string FormatString() { return std::string(); }
+
+}  // namespace details
+}  // namespace Sophus
+
+#endif //SOPHUS_FORMATSTRING_HPP

--- a/thirdparty/sophus/geometry.hpp
+++ b/thirdparty/sophus/geometry.hpp
@@ -1,0 +1,179 @@
+/// @file
+/// Transformations between poses and hyperplanes.
+
+#ifndef GEOMETRY_HPP
+#define GEOMETRY_HPP
+
+#include "se2.hpp"
+#include "se3.hpp"
+#include "so2.hpp"
+#include "so3.hpp"
+#include "types.hpp"
+
+namespace Sophus {
+
+/// Takes in a rotation ``R_foo_plane`` and returns the corresponding line
+/// normal along the y-axis (in reference frame ``foo``).
+///
+template <class T>
+Vector2<T> normalFromSO2(SO2<T> const& R_foo_line) {
+  return R_foo_line.matrix().col(1);
+}
+
+/// Takes in line normal in reference frame foo and constructs a corresponding
+/// rotation matrix ``R_foo_line``.
+///
+/// Precondition: ``normal_foo`` must not be close to zero.
+///
+template <class T>
+SO2<T> SO2FromNormal(Vector2<T> normal_foo) {
+  SOPHUS_ENSURE(normal_foo.squaredNorm() > Constants<T>::epsilon(), "%",
+                normal_foo.transpose());
+  normal_foo.normalize();
+  return SO2<T>(normal_foo.y(), -normal_foo.x());
+}
+
+/// Takes in a rotation ``R_foo_plane`` and returns the corresponding plane
+/// normal along the z-axis
+/// (in reference frame ``foo``).
+///
+template <class T>
+Vector3<T> normalFromSO3(SO3<T> const& R_foo_plane) {
+  return R_foo_plane.matrix().col(2);
+}
+
+/// Takes in plane normal in reference frame foo and constructs a corresponding
+/// rotation matrix ``R_foo_plane``.
+///
+/// Note: The ``plane`` frame is defined as such that the normal points along
+///       the positive z-axis. One can specify hints for the x-axis and y-axis
+///       of the ``plane`` frame.
+///
+/// Preconditions:
+/// - ``normal_foo``, ``xDirHint_foo``, ``yDirHint_foo`` must not be close to
+///   zero.
+/// - ``xDirHint_foo`` and ``yDirHint_foo`` must be approx. perpendicular.
+///
+template <class T>
+Matrix3<T> rotationFromNormal(Vector3<T> const& normal_foo,
+                              Vector3<T> xDirHint_foo = Vector3<T>(T(1), T(0),
+                                                                   T(0)),
+                              Vector3<T> yDirHint_foo = Vector3<T>(T(0), T(1),
+                                                                   T(0))) {
+  SOPHUS_ENSURE(xDirHint_foo.dot(yDirHint_foo) < Constants<T>::epsilon(),
+                "xDirHint (%) and yDirHint (%) must be perpendicular.",
+                xDirHint_foo.transpose(), yDirHint_foo.transpose());
+  using std::abs;
+  using std::sqrt;
+  T const xDirHint_foo_sqr_length = xDirHint_foo.squaredNorm();
+  T const yDirHint_foo_sqr_length = yDirHint_foo.squaredNorm();
+  T const normal_foo_sqr_length = normal_foo.squaredNorm();
+  SOPHUS_ENSURE(xDirHint_foo_sqr_length > Constants<T>::epsilon(), "%",
+                xDirHint_foo.transpose());
+  SOPHUS_ENSURE(yDirHint_foo_sqr_length > Constants<T>::epsilon(), "%",
+                yDirHint_foo.transpose());
+  SOPHUS_ENSURE(normal_foo_sqr_length > Constants<T>::epsilon(), "%",
+                normal_foo.transpose());
+
+  Matrix3<T> basis_foo;
+  basis_foo.col(2) = normal_foo;
+
+  if (abs(xDirHint_foo_sqr_length - T(1)) > Constants<T>::epsilon()) {
+    xDirHint_foo.normalize();
+  }
+  if (abs(yDirHint_foo_sqr_length - T(1)) > Constants<T>::epsilon()) {
+    yDirHint_foo.normalize();
+  }
+  if (abs(normal_foo_sqr_length - T(1)) > Constants<T>::epsilon()) {
+    basis_foo.col(2).normalize();
+  }
+
+  T abs_x_dot_z = abs(basis_foo.col(2).dot(xDirHint_foo));
+  T abs_y_dot_z = abs(basis_foo.col(2).dot(yDirHint_foo));
+  if (abs_x_dot_z < abs_y_dot_z) {
+    // basis_foo.z and xDirHint are far from parallel.
+    basis_foo.col(1) = basis_foo.col(2).cross(xDirHint_foo).normalized();
+    basis_foo.col(0) = basis_foo.col(1).cross(basis_foo.col(2));
+  } else {
+    // basis_foo.z and yDirHint are far from parallel.
+    basis_foo.col(0) = yDirHint_foo.cross(basis_foo.col(2)).normalized();
+    basis_foo.col(1) = basis_foo.col(2).cross(basis_foo.col(0));
+  }
+  T det = basis_foo.determinant();
+  // sanity check
+  SOPHUS_ENSURE(abs(det - T(1)) < Constants<T>::epsilon(),
+                "Determinant of basis is not 1, but %. Basis is \n%\n", det,
+                basis_foo);
+  return basis_foo;
+}
+
+/// Takes in plane normal in reference frame foo and constructs a corresponding
+/// rotation matrix ``R_foo_plane``.
+///
+/// See ``rotationFromNormal`` for details.
+///
+template <class T>
+SO3<T> SO3FromNormal(Vector3<T> const& normal_foo) {
+  return SO3<T>(rotationFromNormal(normal_foo));
+}
+
+/// Returns a line (wrt. to frame ``foo``), given a pose of the ``line`` in
+/// reference frame ``foo``.
+///
+/// Note: The plane is defined by X-axis of the ``line`` frame.
+///
+template <class T>
+Line2<T> lineFromSE2(SE2<T> const& T_foo_line) {
+  return Line2<T>(normalFromSO2(T_foo_line.so2()), T_foo_line.translation());
+}
+
+/// Returns the pose ``T_foo_line``, given a line in reference frame ``foo``.
+///
+/// Note: The line is defined by X-axis of the frame ``line``.
+///
+template <class T>
+SE2<T> SE2FromLine(Line2<T> const& line_foo) {
+  T const d = line_foo.offset();
+  Vector2<T> const n = line_foo.normal();
+  SO2<T> const R_foo_plane = SO2FromNormal(n);
+  return SE2<T>(R_foo_plane, -d * n);
+}
+
+/// Returns a plane (wrt. to frame ``foo``), given a pose of the ``plane`` in
+/// reference frame ``foo``.
+///
+/// Note: The plane is defined by XY-plane of the frame ``plane``.
+///
+template <class T>
+Plane3<T> planeFromSE3(SE3<T> const& T_foo_plane) {
+  return Plane3<T>(normalFromSO3(T_foo_plane.so3()), T_foo_plane.translation());
+}
+
+/// Returns the pose ``T_foo_plane``, given a plane in reference frame ``foo``.
+///
+/// Note: The plane is defined by XY-plane of the frame ``plane``.
+///
+template <class T>
+SE3<T> SE3FromPlane(Plane3<T> const& plane_foo) {
+  T const d = plane_foo.offset();
+  Vector3<T> const n = plane_foo.normal();
+  SO3<T> const R_foo_plane = SO3FromNormal(n);
+  return SE3<T>(R_foo_plane, -d * n);
+}
+
+/// Takes in a hyperplane and returns unique representation by ensuring that the
+/// ``offset`` is not negative.
+///
+template <class T, int N>
+Eigen::Hyperplane<T, N> makeHyperplaneUnique(
+    Eigen::Hyperplane<T, N> const& plane) {
+  if (plane.offset() >= 0) {
+    return plane;
+  }
+
+  return Eigen::Hyperplane<T, N>(-plane.normal(), -plane.offset());
+}
+
+}  // namespace Sophus
+
+#endif  // GEOMETRY_HPP

--- a/thirdparty/sophus/interpolate.hpp
+++ b/thirdparty/sophus/interpolate.hpp
@@ -1,0 +1,38 @@
+/// @file
+/// Interpolation for Lie groups.
+
+#ifndef SOPHUS_INTERPOLATE_HPP
+#define SOPHUS_INTERPOLATE_HPP
+
+#include <Eigen/Eigenvalues>
+
+#include "interpolate_details.hpp"
+
+namespace Sophus {
+
+/// This function interpolates between two Lie group elements ``foo_T_bar``
+/// and ``foo_T_baz`` with an interpolation factor of ``alpha`` in [0, 1].
+///
+/// It returns a pose ``foo_T_quiz`` with ``quiz`` being a frame between ``bar``
+/// and ``baz``. If ``alpha=0`` it returns ``foo_T_bar``. If it is 1, it returns
+/// ``foo_T_bar``.
+///
+/// (Since interpolation on Lie groups is inverse-invariant, we can equivalently
+/// think of the input arguments as being ``bar_T_foo``, ``baz_T_foo`` and the
+/// return value being ``quiz_T_foo``.)
+///
+/// Precondition: ``p`` must be in [0, 1].
+///
+template <class G, class Scalar2 = typename G::Scalar>
+enable_if_t<interp_details::Traits<G>::supported, G> interpolate(
+    G const& foo_T_bar, G const& foo_T_baz, Scalar2 p = Scalar2(0.5f)) {
+  using Scalar = typename G::Scalar;
+  Scalar inter_p(p);
+  SOPHUS_ENSURE(inter_p >= Scalar(0) && inter_p <= Scalar(1),
+                "p (%) must in [0, 1].");
+  return foo_T_bar * G::exp(inter_p * (foo_T_bar.inverse() * foo_T_baz).log());
+}
+
+}  // namespace Sophus
+
+#endif  // SOPHUS_INTERPOLATE_HPP

--- a/thirdparty/sophus/interpolate_details.hpp
+++ b/thirdparty/sophus/interpolate_details.hpp
@@ -1,0 +1,104 @@
+#ifndef SOPHUS_INTERPOLATE_DETAILS_HPP
+#define SOPHUS_INTERPOLATE_DETAILS_HPP
+
+#include "rxso2.hpp"
+#include "rxso3.hpp"
+#include "se2.hpp"
+#include "se3.hpp"
+#include "sim2.hpp"
+#include "sim3.hpp"
+#include "so2.hpp"
+#include "so3.hpp"
+
+namespace Sophus {
+namespace interp_details {
+
+template <class Group>
+struct Traits;
+
+template <class Scalar>
+struct Traits<SO2<Scalar>> {
+  static bool constexpr supported = true;
+
+  static bool hasShortestPathAmbiguity(SO2<Scalar> const& foo_T_bar) {
+    using std::abs;
+    Scalar angle = foo_T_bar.log();
+    return abs(abs(angle) - Constants<Scalar>::pi()) <
+           Constants<Scalar>::epsilon();
+  }
+};
+
+template <class Scalar>
+struct Traits<RxSO2<Scalar>> {
+  static bool constexpr supported = true;
+
+  static bool hasShortestPathAmbiguity(RxSO2<Scalar> const& foo_T_bar) {
+    return Traits<SO2<Scalar>>::hasShortestPathAmbiguity(foo_T_bar.so2());
+  }
+};
+
+template <class Scalar>
+struct Traits<SO3<Scalar>> {
+  static bool constexpr supported = true;
+
+  static bool hasShortestPathAmbiguity(SO3<Scalar> const& foo_T_bar) {
+    using std::abs;
+    Scalar angle = foo_T_bar.logAndTheta().theta;
+    return abs(abs(angle) - Constants<Scalar>::pi()) <
+           Constants<Scalar>::epsilon();
+  }
+};
+
+template <class Scalar>
+struct Traits<RxSO3<Scalar>> {
+  static bool constexpr supported = true;
+
+  static bool hasShortestPathAmbiguity(RxSO3<Scalar> const& foo_T_bar) {
+    return Traits<SO3<Scalar>>::hasShortestPathAmbiguity(foo_T_bar.so3());
+  }
+};
+
+template <class Scalar>
+struct Traits<SE2<Scalar>> {
+  static bool constexpr supported = true;
+
+  static bool hasShortestPathAmbiguity(SE2<Scalar> const& foo_T_bar) {
+    return Traits<SO2<Scalar>>::hasShortestPathAmbiguity(foo_T_bar.so2());
+  }
+};
+
+template <class Scalar>
+struct Traits<SE3<Scalar>> {
+  static bool constexpr supported = true;
+
+  static bool hasShortestPathAmbiguity(SE3<Scalar> const& foo_T_bar) {
+    return Traits<SO3<Scalar>>::hasShortestPathAmbiguity(foo_T_bar.so3());
+  }
+};
+
+template <class Scalar>
+struct Traits<Sim2<Scalar>> {
+  static bool constexpr supported = true;
+
+  static bool hasShortestPathAmbiguity(Sim2<Scalar> const& foo_T_bar) {
+    return Traits<SO2<Scalar>>::hasShortestPathAmbiguity(
+        foo_T_bar.rxso2().so2());
+    ;
+  }
+};
+
+template <class Scalar>
+struct Traits<Sim3<Scalar>> {
+  static bool constexpr supported = true;
+
+  static bool hasShortestPathAmbiguity(Sim3<Scalar> const& foo_T_bar) {
+    return Traits<SO3<Scalar>>::hasShortestPathAmbiguity(
+        foo_T_bar.rxso3().so3());
+    ;
+  }
+};
+
+}  // namespace interp_details
+}  // namespace Sophus
+
+#endif  // SOPHUS_INTERPOLATE_DETAILS_HPP

--- a/thirdparty/sophus/num_diff.hpp
+++ b/thirdparty/sophus/num_diff.hpp
@@ -1,0 +1,93 @@
+/// @file
+/// Numerical differentiation using finite differences
+
+#ifndef SOPHUS_NUM_DIFF_HPP
+#define SOPHUS_NUM_DIFF_HPP
+
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include "types.hpp"
+
+namespace Sophus {
+
+namespace details {
+template <class Scalar>
+class Curve {
+ public:
+  template <class Fn>
+  static auto num_diff(Fn curve, Scalar t, Scalar h) -> decltype(curve(t)) {
+    using ReturnType = decltype(curve(t));
+    static_assert(std::is_floating_point<Scalar>::value,
+                  "Scalar must be a floating point type.");
+    static_assert(IsFloatingPoint<ReturnType>::value,
+                  "ReturnType must be either a floating point scalar, "
+                  "vector or matrix.");
+
+    return (curve(t + h) - curve(t - h)) / (Scalar(2) * h);
+  }
+};
+
+template <class Scalar, int N, int M>
+class VectorField {
+ public:
+  static Eigen::Matrix<Scalar, N, M> num_diff(
+      std::function<Sophus::Vector<Scalar, N>(Sophus::Vector<Scalar, M>)>
+          vector_field,
+      Sophus::Vector<Scalar, M> const& a, Scalar eps) {
+    static_assert(std::is_floating_point<Scalar>::value,
+                  "Scalar must be a floating point type.");
+    Eigen::Matrix<Scalar, N, M> J;
+    Sophus::Vector<Scalar, M> h;
+    h.setZero();
+    for (int i = 0; i < M; ++i) {
+      h[i] = eps;
+      J.col(i) =
+          (vector_field(a + h) - vector_field(a - h)) / (Scalar(2) * eps);
+      h[i] = Scalar(0);
+    }
+
+    return J;
+  }
+};
+
+template <class Scalar, int N>
+class VectorField<Scalar, N, 1> {
+ public:
+  static Eigen::Matrix<Scalar, N, 1> num_diff(
+      std::function<Sophus::Vector<Scalar, N>(Scalar)> vector_field,
+      Scalar const& a, Scalar eps) {
+    return details::Curve<Scalar>::num_diff(std::move(vector_field), a, eps);
+  }
+};
+}  // namespace details
+
+/// Calculates the derivative of a curve at a point ``t``.
+///
+/// Here, a curve is a function from a Scalar to a Euclidean space. Thus, it
+/// returns either a Scalar, a vector or a matrix.
+///
+template <class Scalar, class Fn>
+auto curveNumDiff(Fn curve, Scalar t,
+                  Scalar h = Constants<Scalar>::epsilonSqrt())
+    -> decltype(details::Curve<Scalar>::num_diff(std::move(curve), t, h)) {
+  return details::Curve<Scalar>::num_diff(std::move(curve), t, h);
+}
+
+/// Calculates the derivative of a vector field at a point ``a``.
+///
+/// Here, a vector field is a function from a vector space to another vector
+/// space.
+///
+template <class Scalar, int N, int M, class ScalarOrVector, class Fn>
+Eigen::Matrix<Scalar, N, M> vectorFieldNumDiff(
+    Fn vector_field, ScalarOrVector const& a,
+    Scalar eps = Constants<Scalar>::epsilonSqrt()) {
+  return details::VectorField<Scalar, N, M>::num_diff(std::move(vector_field),
+                                                      a, eps);
+}
+
+}  // namespace Sophus
+
+#endif  // SOPHUS_NUM_DIFF_HPP

--- a/thirdparty/sophus/rotation_matrix.hpp
+++ b/thirdparty/sophus/rotation_matrix.hpp
@@ -1,0 +1,84 @@
+/// @file
+/// Rotation matrix helper functions.
+
+#ifndef SOPHUS_ROTATION_MATRIX_HPP
+#define SOPHUS_ROTATION_MATRIX_HPP
+
+#include <Eigen/Dense>
+#include <Eigen/SVD>
+
+#include "types.hpp"
+
+namespace Sophus {
+
+/// Takes in arbitrary square matrix and returns true if it is
+/// orthogonal.
+template <class D>
+SOPHUS_FUNC bool isOrthogonal(Eigen::MatrixBase<D> const& R) {
+  using Scalar = typename D::Scalar;
+  static int const N = D::RowsAtCompileTime;
+  static int const M = D::ColsAtCompileTime;
+
+  static_assert(N == M, "must be a square matrix");
+  static_assert(N >= 2, "must have compile time dimension >= 2");
+
+  return (R * R.transpose() - Matrix<Scalar, N, N>::Identity()).norm() <
+         Constants<Scalar>::epsilon();
+}
+
+/// Takes in arbitrary square matrix and returns true if it is
+/// "scaled-orthogonal" with positive determinant.
+///
+template <class D>
+SOPHUS_FUNC bool isScaledOrthogonalAndPositive(Eigen::MatrixBase<D> const& sR) {
+  using Scalar = typename D::Scalar;
+  static int const N = D::RowsAtCompileTime;
+  static int const M = D::ColsAtCompileTime;
+  using std::pow;
+  using std::sqrt;
+
+  Scalar det = sR.determinant();
+
+  if (det <= Scalar(0)) {
+    return false;
+  }
+
+  Scalar scale_sqr = pow(det, Scalar(2. / N));
+
+  static_assert(N == M, "must be a square matrix");
+  static_assert(N >= 2, "must have compile time dimension >= 2");
+
+  return (sR * sR.transpose() - scale_sqr * Matrix<Scalar, N, N>::Identity())
+             .template lpNorm<Eigen::Infinity>() <
+         sqrt(Constants<Scalar>::epsilon());
+}
+
+/// Takes in arbitrary square matrix (2x2 or larger) and returns closest
+/// orthogonal matrix with positive determinant.
+template <class D>
+SOPHUS_FUNC enable_if_t<
+    std::is_floating_point<typename D::Scalar>::value,
+    Matrix<typename D::Scalar, D::RowsAtCompileTime, D::RowsAtCompileTime>>
+makeRotationMatrix(Eigen::MatrixBase<D> const& R) {
+  using Scalar = typename D::Scalar;
+  static int const N = D::RowsAtCompileTime;
+  static int const M = D::ColsAtCompileTime;
+
+  static_assert(N == M, "must be a square matrix");
+  static_assert(N >= 2, "must have compile time dimension >= 2");
+
+  Eigen::JacobiSVD<Matrix<Scalar, N, N>> svd(
+      R, Eigen::ComputeFullU | Eigen::ComputeFullV);
+
+  // Determine determinant of orthogonal matrix U*V'.
+  Scalar d = (svd.matrixU() * svd.matrixV().transpose()).determinant();
+  // Starting from the identity matrix D, set the last entry to d (+1 or
+  // -1),  so that det(U*D*V') = 1.
+  Matrix<Scalar, N, N> Diag = Matrix<Scalar, N, N>::Identity();
+  Diag(N - 1, N - 1) = d;
+  return svd.matrixU() * Diag * svd.matrixV().transpose();
+}
+
+}  // namespace Sophus
+
+#endif  // SOPHUS_ROTATION_MATRIX_HPP

--- a/thirdparty/sophus/rxso2.hpp
+++ b/thirdparty/sophus/rxso2.hpp
@@ -1,0 +1,660 @@
+/// @file
+/// Direct product R X SO(2) - rotation and scaling in 2d.
+
+#ifndef SOPHUS_RXSO2_HPP
+#define SOPHUS_RXSO2_HPP
+
+#include "so2.hpp"
+
+namespace Sophus {
+template <class Scalar_, int Options = 0>
+class RxSO2;
+using RxSO2d = RxSO2<double>;
+using RxSO2f = RxSO2<float>;
+}  // namespace Sophus
+
+namespace Eigen {
+namespace internal {
+
+template <class Scalar_, int Options_>
+struct traits<Sophus::RxSO2<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using ComplexType = Sophus::Vector2<Scalar, Options>;
+};
+
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::RxSO2<Scalar_>, Options_>>
+    : traits<Sophus::RxSO2<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using ComplexType = Map<Sophus::Vector2<Scalar>, Options>;
+};
+
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::RxSO2<Scalar_> const, Options_>>
+    : traits<Sophus::RxSO2<Scalar_, Options_> const> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using ComplexType = Map<Sophus::Vector2<Scalar> const, Options>;
+};
+}  // namespace internal
+}  // namespace Eigen
+
+namespace Sophus {
+
+/// RxSO2 base type - implements RxSO2 class but is storage agnostic
+///
+/// This class implements the group ``R+ x SO(2)``, the direct product of the
+/// group of positive scalar 2x2 matrices (= isomorph to the positive
+/// real numbers) and the two-dimensional special orthogonal group SO(2).
+/// Geometrically, it is the group of rotation and scaling in two dimensions.
+/// As a matrix groups, R+ x SO(2) consists of matrices of the form ``s * R``
+/// where ``R`` is an orthogonal matrix with ``det(R) = 1`` and ``s > 0``
+/// being a positive real number. In particular, it has the following form:
+///
+///     | s * cos(theta)  s * -sin(theta) |
+///     | s * sin(theta)  s *  cos(theta) |
+///
+/// where ``theta`` being the rotation angle. Internally, it is represented by
+/// the first column of the rotation matrix, or in other words by a non-zero
+/// complex number.
+///
+/// R+ x SO(2) is not compact, but a commutative group. First it is not compact
+/// since the scale factor is not bound. Second it is commutative since
+/// ``sR(alpha, s1) * sR(beta, s2) = sR(beta, s2) * sR(alpha, s1)``,  simply
+/// because ``alpha + beta = beta + alpha`` and ``s1 * s2 = s2 * s1`` with
+/// ``alpha`` and ``beta`` being rotation angles and ``s1``, ``s2`` being scale
+/// factors.
+///
+/// This class has the explicit class invariant that the scale ``s`` is not
+/// too close to zero. Strictly speaking, it must hold that:
+///
+///   ``complex().norm() >= Constants::epsilon()``.
+///
+/// In order to obey this condition, group multiplication is implemented with
+/// saturation such that a product always has a scale which is equal or greater
+/// this threshold.
+template <class Derived>
+class RxSO2Base {
+ public:
+  static constexpr int Options = Eigen::internal::traits<Derived>::Options;
+  using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
+  using ComplexType = typename Eigen::internal::traits<Derived>::ComplexType;
+  using ComplexTemporaryType = Sophus::Vector2<Scalar, Options>;
+
+  /// Degrees of freedom of manifold, number of dimensions in tangent space
+  /// (one for rotation and one for scaling).
+  static int constexpr DoF = 2;
+  /// Number of internal parameters used (complex number is a tuple).
+  static int constexpr num_parameters = 2;
+  /// Group transformations are 2x2 matrices.
+  static int constexpr N = 2;
+  using Transformation = Matrix<Scalar, N, N>;
+  using Point = Vector2<Scalar>;
+  using HomogeneousPoint = Vector3<Scalar>;
+  using Line = ParametrizedLine2<Scalar>;
+  using Tangent = Vector<Scalar, DoF>;
+  using Adjoint = Matrix<Scalar, DoF, DoF>;
+
+  /// For binary operations the return type is determined with the
+  /// ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  /// types, as well as other compatible scalar types such as Ceres::Jet and
+  /// double scalars with RxSO2 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
+
+  template <typename OtherDerived>
+  using RxSO2Product = RxSO2<ReturnScalar<OtherDerived>>;
+
+  template <typename PointDerived>
+  using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector3<ReturnScalar<HPointDerived>>;
+
+  /// Adjoint transformation
+  ///
+  /// This function return the adjoint transformation ``Ad`` of the group
+  /// element ``A`` such that for all ``x`` it holds that
+  /// ``hat(Ad_A * x) = A * hat(x) A^{-1}``. See hat-operator below.
+  ///
+  /// For RxSO(2), it simply returns the identity matrix.
+  ///
+  SOPHUS_FUNC Adjoint Adj() const { return Adjoint::Identity(); }
+
+  /// Returns rotation angle.
+  ///
+  SOPHUS_FUNC Scalar angle() const { return SO2<Scalar>(complex()).log(); }
+
+  /// Returns copy of instance casted to NewScalarType.
+  ///
+  template <class NewScalarType>
+  SOPHUS_FUNC RxSO2<NewScalarType> cast() const {
+    return RxSO2<NewScalarType>(complex().template cast<NewScalarType>());
+  }
+
+  /// This provides unsafe read/write access to internal data. RxSO(2) is
+  /// represented by a complex number (two parameters). When using direct
+  /// write access, the user needs to take care of that the complex number is
+  /// not set close to zero.
+  ///
+  /// Note: The first parameter represents the real part, while the
+  /// second parameter represent the imaginary part.
+  ///
+  SOPHUS_FUNC Scalar* data() { return complex_nonconst().data(); }
+
+  /// Const version of data() above.
+  ///
+  SOPHUS_FUNC Scalar const* data() const { return complex().data(); }
+
+  /// Returns group inverse.
+  ///
+  SOPHUS_FUNC RxSO2<Scalar> inverse() const {
+    Scalar squared_scale = complex().squaredNorm();
+    return RxSO2<Scalar>(complex().x() / squared_scale,
+                         -complex().y() / squared_scale);
+  }
+
+  /// Logarithmic map
+  ///
+  /// Computes the logarithm, the inverse of the group exponential which maps
+  /// element of the group (scaled rotation matrices) to elements of the tangent
+  /// space (rotation-vector plus logarithm of scale factor).
+  ///
+  /// To be specific, this function computes ``vee(logmat(.))`` with
+  /// ``logmat(.)`` being the matrix logarithm and ``vee(.)`` the vee-operator
+  /// of RxSO2.
+  ///
+  SOPHUS_FUNC Tangent log() const {
+    using std::log;
+    Tangent theta_sigma;
+    theta_sigma[1] = log(scale());
+    theta_sigma[0] = SO2<Scalar>(complex()).log();
+    return theta_sigma;
+  }
+
+  /// Returns 2x2 matrix representation of the instance.
+  ///
+  /// For RxSO2, the matrix representation is an scaled orthogonal matrix ``sR``
+  /// with ``det(R)=s^2``, thus a scaled rotation matrix ``R``  with scale
+  /// ``s``.
+  ///
+  SOPHUS_FUNC Transformation matrix() const {
+    Transformation sR;
+    // clang-format off
+    sR << complex()[0], -complex()[1],
+          complex()[1],  complex()[0];
+    // clang-format on
+    return sR;
+  }
+
+  /// Assignment operator.
+  ///
+  SOPHUS_FUNC RxSO2Base& operator=(RxSO2Base const& other) = default;
+
+  /// Assignment-like operator from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC RxSO2Base<Derived>& operator=(
+      RxSO2Base<OtherDerived> const& other) {
+    complex_nonconst() = other.complex();
+    return *this;
+  }
+
+  /// Group multiplication, which is rotation concatenation and scale
+  /// multiplication.
+  ///
+  /// Note: This function performs saturation for products close to zero in
+  /// order to ensure the class invariant.
+  ///
+  template <typename OtherDerived>
+  SOPHUS_FUNC RxSO2Product<OtherDerived> operator*(
+      RxSO2Base<OtherDerived> const& other) const {
+    using ResultT = ReturnScalar<OtherDerived>;
+
+    Scalar lhs_real = complex().x();
+    Scalar lhs_imag = complex().y();
+    typename OtherDerived::Scalar const& rhs_real = other.complex().x();
+    typename OtherDerived::Scalar const& rhs_imag = other.complex().y();
+    /// complex multiplication
+    typename RxSO2Product<OtherDerived>::ComplexType result_complex(
+        lhs_real * rhs_real - lhs_imag * rhs_imag,
+        lhs_real * rhs_imag + lhs_imag * rhs_real);
+
+    const ResultT squared_scale = result_complex.squaredNorm();
+
+    if (squared_scale <
+        Constants<ResultT>::epsilon() * Constants<ResultT>::epsilon()) {
+      /// Saturation to ensure class invariant.
+      result_complex.normalize();
+      result_complex *= Constants<ResultT>::epsilon();
+    }
+    return RxSO2Product<OtherDerived>(result_complex);
+  }
+
+  /// Group action on 2-points.
+  ///
+  /// This function rotates a 2 dimensional point ``p`` by the SO2 element
+  /// ``bar_R_foo`` (= rotation matrix) and scales it by the scale factor ``s``:
+  ///
+  ///   ``p_bar = s * (bar_R_foo * p_foo)``.
+  ///
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 2>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
+    return matrix() * p;
+  }
+
+  /// Group action on homogeneous 2-points. See above for more details.
+  ///
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 3>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const auto rsp = *this * p.template head<2>();
+    return HomogeneousPointProduct<HPointDerived>(rsp(0), rsp(1), p(2));
+  }
+
+  /// Group action on lines.
+  ///
+  /// This function rotates a parameterized line ``l(t) = o + t * d`` by the SO2
+  /// element and scales it by the scale factor
+  ///
+  /// Origin ``o`` is rotated and scaled
+  /// Direction ``d`` is rotated (preserving it's norm)
+  ///
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), (*this) * l.direction() / scale());
+  }
+
+  /// In-place group multiplication. This method is only valid if the return
+  /// type of the multiplication is compatible with this SO2's Scalar type.
+  ///
+  /// Note: This function performs saturation for products close to zero in
+  /// order to ensure the class invariant.
+  ///
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC RxSO2Base<Derived>& operator*=(
+      RxSO2Base<OtherDerived> const& other) {
+    *static_cast<Derived*>(this) = *this * other;
+    return *this;
+  }
+
+  /// Returns internal parameters of RxSO(2).
+  ///
+  /// It returns (c[0], c[1]), with c being the  complex number.
+  ///
+  SOPHUS_FUNC Sophus::Vector<Scalar, num_parameters> params() const {
+    return complex();
+  }
+
+  /// Sets non-zero complex
+  ///
+  /// Precondition: ``z`` must not be close to zero.
+  SOPHUS_FUNC void setComplex(Vector2<Scalar> const& z) {
+    SOPHUS_ENSURE(z.squaredNorm() > Constants<Scalar>::epsilon() *
+                                        Constants<Scalar>::epsilon(),
+                  "Scale factor must be greater-equal epsilon.");
+    static_cast<Derived*>(this)->complex_nonconst() = z;
+  }
+
+  /// Accessor of complex.
+  ///
+  SOPHUS_FUNC ComplexType const& complex() const {
+    return static_cast<Derived const*>(this)->complex();
+  }
+
+  /// Returns rotation matrix.
+  ///
+  SOPHUS_FUNC Transformation rotationMatrix() const {
+    ComplexTemporaryType norm_quad = complex();
+    norm_quad.normalize();
+    return SO2<Scalar>(norm_quad).matrix();
+  }
+
+  /// Returns scale.
+  ///
+  SOPHUS_FUNC
+  Scalar scale() const { return complex().norm(); }
+
+  /// Setter of rotation angle, leaves scale as is.
+  ///
+  SOPHUS_FUNC void setAngle(Scalar const& theta) { setSO2(SO2<Scalar>(theta)); }
+
+  /// Setter of complex using rotation matrix ``R``, leaves scale as is.
+  ///
+  /// Precondition: ``R`` must be orthogonal with determinant of one.
+  ///
+  SOPHUS_FUNC void setRotationMatrix(Transformation const& R) {
+    setSO2(SO2<Scalar>(R));
+  }
+
+  /// Sets scale and leaves rotation as is.
+  ///
+  SOPHUS_FUNC void setScale(Scalar const& scale) {
+    using std::sqrt;
+    complex_nonconst().normalize();
+    complex_nonconst() *= scale;
+  }
+
+  /// Setter of complex number using scaled rotation matrix ``sR``.
+  ///
+  /// Precondition: The 2x2 matrix must be "scaled orthogonal"
+  ///               and have a positive determinant.
+  ///
+  SOPHUS_FUNC void setScaledRotationMatrix(Transformation const& sR) {
+    SOPHUS_ENSURE(isScaledOrthogonalAndPositive(sR),
+                  "sR must be scaled orthogonal:\n %", sR);
+    complex_nonconst() = sR.col(0);
+  }
+
+  /// Setter of SO(2) rotations, leaves scale as is.
+  ///
+  SOPHUS_FUNC void setSO2(SO2<Scalar> const& so2) {
+    using std::sqrt;
+    Scalar saved_scale = scale();
+    complex_nonconst() = so2.unit_complex();
+    complex_nonconst() *= saved_scale;
+  }
+
+  SOPHUS_FUNC SO2<Scalar> so2() const { return SO2<Scalar>(complex()); }
+
+ protected:
+  /// Mutator of complex is private to ensure class invariant.
+  ///
+  SOPHUS_FUNC ComplexType& complex_nonconst() {
+    return static_cast<Derived*>(this)->complex_nonconst();
+  }
+};
+
+/// RxSO2 using storage; derived from RxSO2Base.
+template <class Scalar_, int Options>
+class RxSO2 : public RxSO2Base<RxSO2<Scalar_, Options>> {
+ public:
+  using Base = RxSO2Base<RxSO2<Scalar_, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+  using ComplexMember = Eigen::Matrix<Scalar, 2, 1, Options>;
+
+  /// ``Base`` is friend so complex_nonconst can be accessed from ``Base``.
+  friend class RxSO2Base<RxSO2<Scalar_, Options>>;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// Default constructor initializes complex number to identity rotation and
+  /// scale to 1.
+  ///
+  SOPHUS_FUNC RxSO2() : complex_(Scalar(1), Scalar(0)) {}
+
+  /// Copy constructor
+  ///
+  SOPHUS_FUNC RxSO2(RxSO2 const& other) = default;
+
+  /// Copy-like constructor from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC RxSO2(RxSO2Base<OtherDerived> const& other)
+      : complex_(other.complex()) {}
+
+  /// Constructor from scaled rotation matrix
+  ///
+  /// Precondition: rotation matrix need to be scaled orthogonal with
+  /// determinant of ``s^2``.
+  ///
+  SOPHUS_FUNC explicit RxSO2(Transformation const& sR) {
+    this->setScaledRotationMatrix(sR);
+  }
+
+  /// Constructor from scale factor and rotation matrix ``R``.
+  ///
+  /// Precondition: Rotation matrix ``R`` must to be orthogonal with determinant
+  ///               of 1 and ``scale`` must to be close to zero.
+  ///
+  SOPHUS_FUNC RxSO2(Scalar const& scale, Transformation const& R)
+      : RxSO2((scale * SO2<Scalar>(R).unit_complex()).eval()) {}
+
+  /// Constructor from scale factor and SO2
+  ///
+  /// Precondition: ``scale`` must be close to zero.
+  ///
+  SOPHUS_FUNC RxSO2(Scalar const& scale, SO2<Scalar> const& so2)
+      : RxSO2((scale * so2.unit_complex()).eval()) {}
+
+  /// Constructor from complex number.
+  ///
+  /// Precondition: complex number must not be close to zero.
+  ///
+  SOPHUS_FUNC explicit RxSO2(Vector2<Scalar> const& z) : complex_(z) {
+    SOPHUS_ENSURE(complex_.squaredNorm() >= Constants<Scalar>::epsilon() *
+                                                Constants<Scalar>::epsilon(),
+                  "Scale factor must be greater-equal epsilon: % vs %",
+                  complex_.squaredNorm(),
+                  Constants<Scalar>::epsilon() * Constants<Scalar>::epsilon());
+  }
+
+  /// Constructor from complex number.
+  ///
+  /// Precondition: complex number must not be close to zero.
+  ///
+  SOPHUS_FUNC explicit RxSO2(Scalar const& real, Scalar const& imag)
+      : RxSO2(Vector2<Scalar>(real, imag)) {}
+
+  /// Accessor of complex.
+  ///
+  SOPHUS_FUNC ComplexMember const& complex() const { return complex_; }
+
+  /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.
+  ///
+  SOPHUS_FUNC static Transformation Dxi_exp_x_matrix_at_0(int i) {
+    return generator(i);
+  }
+  /// Group exponential
+  ///
+  /// This functions takes in an element of tangent space (= rotation angle
+  /// plus logarithm of scale) and returns the corresponding element of the
+  /// group RxSO2.
+  ///
+  /// To be more specific, this function computes ``expmat(hat(theta))``
+  /// with ``expmat(.)`` being the matrix exponential and ``hat(.)`` being the
+  /// hat()-operator of RSO2.
+  ///
+  SOPHUS_FUNC static RxSO2<Scalar> exp(Tangent const& a) {
+    using std::exp;
+
+    Scalar const theta = a[0];
+    Scalar const sigma = a[1];
+    Scalar s = exp(sigma);
+    Vector2<Scalar> z = SO2<Scalar>::exp(theta).unit_complex();
+    z *= s;
+    return RxSO2<Scalar>(z);
+  }
+
+  /// Returns the ith infinitesimal generators of ``R+ x SO(2)``.
+  ///
+  /// The infinitesimal generators of RxSO2 are:
+  ///
+  /// ```
+  ///         |  0 -1 |
+  ///   G_0 = |  1  0 |
+  ///
+  ///         |  1  0 |
+  ///   G_1 = |  0  1 |
+  /// ```
+  ///
+  /// Precondition: ``i`` must be 0, or 1.
+  ///
+  SOPHUS_FUNC static Transformation generator(int i) {
+    SOPHUS_ENSURE(i >= 0 && i <= 1, "i should be 0 or 1.");
+    Tangent e;
+    e.setZero();
+    e[i] = Scalar(1);
+    return hat(e);
+  }
+
+  /// hat-operator
+  ///
+  /// It takes in the 2-vector representation ``a`` (= rotation angle plus
+  /// logarithm of scale) and  returns the corresponding matrix representation
+  /// of Lie algebra element.
+  ///
+  /// Formally, the hat()-operator of RxSO2 is defined as
+  ///
+  ///   ``hat(.): R^2 -> R^{2x2},  hat(a) = sum_i a_i * G_i``  (for i=0,1,2)
+  ///
+  /// with ``G_i`` being the ith infinitesimal generator of RxSO2.
+  ///
+  /// The corresponding inverse is the vee()-operator, see below.
+  ///
+  SOPHUS_FUNC static Transformation hat(Tangent const& a) {
+    Transformation A;
+    // clang-format off
+    A << a(1), -a(0),
+         a(0),  a(1);
+    // clang-format on
+    return A;
+  }
+
+  /// Lie bracket
+  ///
+  /// It computes the Lie bracket of RxSO(2). To be more specific, it computes
+  ///
+  ///   ``[omega_1, omega_2]_rxso2 := vee([hat(omega_1), hat(omega_2)])``
+  ///
+  /// with ``[A,B] := AB-BA`` being the matrix commutator, ``hat(.)`` the
+  /// hat()-operator and ``vee(.)`` the vee()-operator of RxSO2.
+  ///
+  SOPHUS_FUNC static Tangent lieBracket(Tangent const&, Tangent const&) {
+    Vector2<Scalar> res;
+    res.setZero();
+    return res;
+  }
+
+  /// Draw uniform sample from RxSO(2) manifold.
+  ///
+  /// The scale factor is drawn uniformly in log2-space from [-1, 1],
+  /// hence the scale is in [0.5, 2)].
+  ///
+  template <class UniformRandomBitGenerator>
+  static RxSO2 sampleUniform(UniformRandomBitGenerator& generator) {
+    std::uniform_real_distribution<Scalar> uniform(Scalar(-1), Scalar(1));
+    using std::exp2;
+    return RxSO2(exp2(uniform(generator)),
+                 SO2<Scalar>::sampleUniform(generator));
+  }
+
+  /// vee-operator
+  ///
+  /// It takes the 2x2-matrix representation ``Omega`` and maps it to the
+  /// corresponding vector representation of Lie algebra.
+  ///
+  /// This is the inverse of the hat()-operator, see above.
+  ///
+  /// Precondition: ``Omega`` must have the following structure:
+  ///
+  ///                |  d -x |
+  ///                |  x  d |
+  ///
+  SOPHUS_FUNC static Tangent vee(Transformation const& Omega) {
+    using std::abs;
+    return Tangent(Omega(1, 0), Omega(0, 0));
+  }
+
+ protected:
+  SOPHUS_FUNC ComplexMember& complex_nonconst() { return complex_; }
+
+  ComplexMember complex_;
+};
+
+}  // namespace Sophus
+
+namespace Eigen {
+
+/// Specialization of Eigen::Map for ``RxSO2``; derived from  RxSO2Base.
+///
+/// Allows us to wrap RxSO2 objects around POD array (e.g. external z style
+/// complex).
+template <class Scalar_, int Options>
+class Map<Sophus::RxSO2<Scalar_>, Options>
+    : public Sophus::RxSO2Base<Map<Sophus::RxSO2<Scalar_>, Options>> {
+  using Base = Sophus::RxSO2Base<Map<Sophus::RxSO2<Scalar_>, Options>>;
+
+ public:
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+
+  /// ``Base`` is friend so complex_nonconst can be accessed from ``Base``.
+  friend class Sophus::RxSO2Base<Map<Sophus::RxSO2<Scalar_>, Options>>;
+
+  // LCOV_EXCL_START
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  // LCOV_EXCL_STOP
+  using Base::operator*=;
+  using Base::operator*;
+
+  SOPHUS_FUNC Map(Scalar* coeffs) : complex_(coeffs) {}
+
+  /// Accessor of complex.
+  ///
+  SOPHUS_FUNC
+  Map<Sophus::Vector2<Scalar>, Options> const& complex() const {
+    return complex_;
+  }
+
+ protected:
+  SOPHUS_FUNC Map<Sophus::Vector2<Scalar>, Options>& complex_nonconst() {
+    return complex_;
+  }
+
+  Map<Sophus::Vector2<Scalar>, Options> complex_;
+};
+
+/// Specialization of Eigen::Map for ``RxSO2 const``; derived from  RxSO2Base.
+///
+/// Allows us to wrap RxSO2 objects around POD array (e.g. external z style
+/// complex).
+template <class Scalar_, int Options>
+class Map<Sophus::RxSO2<Scalar_> const, Options>
+    : public Sophus::RxSO2Base<Map<Sophus::RxSO2<Scalar_> const, Options>> {
+ public:
+  using Base = Sophus::RxSO2Base<Map<Sophus::RxSO2<Scalar_> const, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+
+  using Base::operator*=;
+  using Base::operator*;
+
+  SOPHUS_FUNC
+  Map(Scalar const* coeffs) : complex_(coeffs) {}
+
+  /// Accessor of complex.
+  ///
+  SOPHUS_FUNC
+  Map<Sophus::Vector2<Scalar> const, Options> const& complex() const {
+    return complex_;
+  }
+
+ protected:
+  Map<Sophus::Vector2<Scalar> const, Options> const complex_;
+};
+}  // namespace Eigen
+
+#endif  /// SOPHUS_RXSO2_HPP

--- a/thirdparty/sophus/rxso3.hpp
+++ b/thirdparty/sophus/rxso3.hpp
@@ -1,838 +1,730 @@
-// This file is part of Sophus.
-//
-// Copyright 2012-2013 Hauke Strasdat
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal in the Software without restriction, including without limitation the
-// rights  to use, copy, modify, merge, publish, distribute, sublicense, and/or
-// sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
+/// @file
+/// Direct product R X SO(3) - rotation and scaling in 3d.
 
 #ifndef SOPHUS_RXSO3_HPP
-#define RXSO3_HPP
+#define SOPHUS_RXSO3_HPP
 
-#include "sophus.hpp"
 #include "so3.hpp"
 
-////////////////////////////////////////////////////////////////////////////
-// Forward Declarations / typedefs
-////////////////////////////////////////////////////////////////////////////
-
 namespace Sophus {
-template<typename _Scalar, int _Options=0> class RxSO3Group;
-typedef RxSO3Group<double> ScSO3 EIGEN_DEPRECATED;
-typedef RxSO3Group<double> RxSO3d; /**< double precision RxSO3 */
-typedef RxSO3Group<float> RxSO3f;  /**< single precision RxSO3 */
-}
-
-////////////////////////////////////////////////////////////////////////////
-// Eigen Traits (For querying derived types in CRTP hierarchy)
-////////////////////////////////////////////////////////////////////////////
+template <class Scalar_, int Options = 0>
+class RxSO3;
+using RxSO3d = RxSO3<double>;
+using RxSO3f = RxSO3<float>;
+}  // namespace Sophus
 
 namespace Eigen {
 namespace internal {
 
-template<typename _Scalar, int _Options>
-struct traits<Sophus::RxSO3Group<_Scalar,_Options> > {
-  typedef _Scalar Scalar;
-  typedef Quaternion<Scalar> QuaternionType;
+template <class Scalar_, int Options_>
+struct traits<Sophus::RxSO3<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using QuaternionType = Eigen::Quaternion<Scalar, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<Sophus::RxSO3Group<_Scalar>, _Options> >
-    : traits<Sophus::RxSO3Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<Quaternion<Scalar>,_Options> QuaternionType;
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::RxSO3<Scalar_>, Options_>>
+    : traits<Sophus::RxSO3<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using QuaternionType = Map<Eigen::Quaternion<Scalar>, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<const Sophus::RxSO3Group<_Scalar>, _Options> >
-    : traits<const Sophus::RxSO3Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<const Quaternion<Scalar>,_Options> QuaternionType;
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::RxSO3<Scalar_> const, Options_>>
+    : traits<Sophus::RxSO3<Scalar_, Options_> const> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using QuaternionType = Map<Eigen::Quaternion<Scalar> const, Options>;
 };
-
-}
-}
+}  // namespace internal
+}  // namespace Eigen
 
 namespace Sophus {
-using namespace Eigen;
 
-class ScaleNotPositive : public SophusException {
-public:
-  ScaleNotPositive ()
-    : SophusException("Scale factor is not positive") {
-  }
-};
+/// RxSO3 base type - implements RxSO3 class but is storage agnostic
+///
+/// This class implements the group ``R+ x SO(3)``, the direct product of the
+/// group of positive scalar 3x3 matrices (= isomorph to the positive
+/// real numbers) and the three-dimensional special orthogonal group SO(3).
+/// Geometrically, it is the group of rotation and scaling in three dimensions.
+/// As a matrix groups, RxSO3 consists of matrices of the form ``s * R``
+/// where ``R`` is an orthogonal matrix with ``det(R)=1`` and ``s > 0``
+/// being a positive real number.
+///
+/// Internally, RxSO3 is represented by the group of non-zero quaternions.
+/// In particular, the scale equals the squared(!) norm of the quaternion ``q``,
+/// ``s = |q|^2``. This is a most compact representation since the degrees of
+/// freedom (DoF) of RxSO3 (=4) equals the number of internal parameters (=4).
+///
+/// This class has the explicit class invariant that the scale ``s`` is not
+/// too close to zero. Strictly speaking, it must hold that:
+///
+///   ``quaternion().squaredNorm() >= Constants::epsilon()``.
+///
+/// In order to obey this condition, group multiplication is implemented with
+/// saturation such that a product always has a scale which is equal or greater
+/// this threshold.
+template <class Derived>
+class RxSO3Base {
+ public:
+  static constexpr int Options = Eigen::internal::traits<Derived>::Options;
+  using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
+  using QuaternionType =
+      typename Eigen::internal::traits<Derived>::QuaternionType;
+  using QuaternionTemporaryType = Eigen::Quaternion<Scalar, Options>;
 
-/**
- * \brief RxSO3 base type - implements RxSO3 class but is storage agnostic
- *
- * This class implements the group \f$ R^{+} \times SO3 \f$ (RxSO3), the direct
- * product of the group of positive scalar matrices (=isomorph to the positive
- * real numbers) and the three-dimensional special orthogonal group SO3.
- * Geometrically, it is the group of rotation and scaling in three dimensions.
- * As a matrix groups, RxSO3 consists of matrices of the form \f$ s\cdot R \f$
- * where \f$ R \f$ is an orthognal matrix with \f$ det(R)=1 \f$ and \f$ s>0 \f$
- * be a positive real number.
- *
- * Internally, RxSO3 is represented by the group of non-zero quaternions. This
- * is a most compact representation since the degrees of freedom (DoF) of RxSO3
- * (=4) equals the number of internal parameters (=4).
- *
- * [add more detailed description/tutorial]
- */
-template<typename Derived>
-class RxSO3GroupBase {
-public:
-  /** \brief scalar type, use with care since this might be a Map type  */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
-  /** \brief quaternion reference type */
-  typedef typename internal::traits<Derived>::QuaternionType &
-  QuaternionReference;
-  /** \brief quaternion const reference type */
-  typedef const typename internal::traits<Derived>::QuaternionType &
-  ConstQuaternionReference;
+  /// Degrees of freedom of manifold, number of dimensions in tangent space
+  /// (three for rotation and one for scaling).
+  static int constexpr DoF = 4;
+  /// Number of internal parameters used (quaternion is a 4-tuple).
+  static int constexpr num_parameters = 4;
+  /// Group transformations are 3x3 matrices.
+  static int constexpr N = 3;
+  using Transformation = Matrix<Scalar, N, N>;
+  using Point = Vector3<Scalar>;
+  using HomogeneousPoint = Vector4<Scalar>;
+  using Line = ParametrizedLine3<Scalar>;
+  using Tangent = Vector<Scalar, DoF>;
+  using Adjoint = Matrix<Scalar, DoF, DoF>;
 
+  struct TangentAndTheta {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  /** \brief degree of freedom of group
-   *         (three for rotation and one for scaling) */
-  static const int DoF = 4;
-  /** \brief number of internal parameters used
-   *         (quaternion for rotation and scaling) */
-  static const int num_parameters = 4;
-  /** \brief group transformations are NxN matrices */
-  static const int N = 3;
-  /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
-  /** \brief point type */
-  typedef Matrix<Scalar,3,1> Point;
-  /** \brief tangent vector type */
-  typedef Matrix<Scalar,DoF,1> Tangent;
-  /** \brief adjoint transformation type */
-  typedef Matrix<Scalar,DoF,DoF> Adjoint;
+    Tangent tangent;
+    Scalar theta;
+  };
 
+  /// For binary operations the return type is determined with the
+  /// ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  /// types, as well as other compatible scalar types such as Ceres::Jet and
+  /// double scalars with RxSO3 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
 
-  /**
-   * \brief Adjoint transformation
-   *
-   * This function return the adjoint transformation \f$ Ad \f$ of the
-   * group instance \f$ A \f$  such that for all \f$ x \f$
-   * it holds that \f$ \widehat{Ad_A\cdot x} = A\widehat{x}A^{-1} \f$
-   * with \f$\ \widehat{\cdot} \f$ being the hat()-operator.
-   *
-   * For RxSO3, it simply returns the rotation matrix corresponding to
-   * \f$ A \f$.
-   */
-  inline
-  const Adjoint Adj() const {
+  template <typename OtherDerived>
+  using RxSO3Product = RxSO3<ReturnScalar<OtherDerived>>;
+
+  template <typename PointDerived>
+  using PointProduct = Vector3<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector4<ReturnScalar<HPointDerived>>;
+
+  /// Adjoint transformation
+  ///
+  /// This function return the adjoint transformation ``Ad`` of the group
+  /// element ``A`` such that for all ``x`` it holds that
+  /// ``hat(Ad_A * x) = A * hat(x) A^{-1}``. See hat-operator below.
+  ///
+  /// For RxSO(3), it simply returns the rotation matrix corresponding to ``A``.
+  ///
+  SOPHUS_FUNC Adjoint Adj() const {
     Adjoint res;
     res.setIdentity();
-    res.template topLeftCorner<3,3>() = rotationMatrix();
+    res.template topLeftCorner<3, 3>() = rotationMatrix();
     return res;
   }
 
-  /**
-   * \returns copy of instance casted to NewScalarType
-   */
-  template<typename NewScalarType>
-  inline RxSO3Group<NewScalarType> cast() const {
-    return RxSO3Group<NewScalarType>(quaternion()
-                                     .template cast<NewScalarType>() );
+  /// Returns copy of instance casted to NewScalarType.
+  ///
+  template <class NewScalarType>
+  SOPHUS_FUNC RxSO3<NewScalarType> cast() const {
+    return RxSO3<NewScalarType>(quaternion().template cast<NewScalarType>());
   }
 
-  /**
-   * \returns pointer to internal data
-   *
-   * This provides direct read/write access to internal data. RxSO3 is
-   * represented by an Eigen::Quaternion (four parameters).
-   *
-   * Note: The first three Scalars represent the imaginary parts, while the
-   * forth Scalar represent the real part.
-   */
-  inline Scalar* data() {
+  /// This provides unsafe read/write access to internal data. RxSO(3) is
+  /// represented by an Eigen::Quaternion (four parameters). When using direct
+  /// write access, the user needs to take care of that the quaternion is not
+  /// set close to zero.
+  ///
+  /// Note: The first three Scalars represent the imaginary parts, while the
+  /// forth Scalar represent the real part.
+  ///
+  SOPHUS_FUNC Scalar* data() { return quaternion_nonconst().coeffs().data(); }
+
+  /// Const version of data() above.
+  ///
+  SOPHUS_FUNC Scalar const* data() const {
     return quaternion().coeffs().data();
   }
 
-  /**
-   * \returns const pointer to internal data
-   *
-   * Const version of data().
-   */
-  inline const Scalar* data() const {
-    return quaternion().coeffs().data();
+  /// Returns group inverse.
+  ///
+  SOPHUS_FUNC RxSO3<Scalar> inverse() const {
+    return RxSO3<Scalar>(quaternion().inverse());
   }
 
-  /**
-   * \brief In-place group multiplication
-   *
-   *  Same as operator*=() for RxSO3.
-   *
-   * \see operator*=()
-   */
-  inline
-  void fastMultiply(const RxSO3Group<Scalar>& other) {
-    quaternion() *= other.quaternion();
+  /// Logarithmic map
+  ///
+  /// Computes the logarithm, the inverse of the group exponential which maps
+  /// element of the group (scaled rotation matrices) to elements of the tangent
+  /// space (rotation-vector plus logarithm of scale factor).
+  ///
+  /// To be specific, this function computes ``vee(logmat(.))`` with
+  /// ``logmat(.)`` being the matrix logarithm and ``vee(.)`` the vee-operator
+  /// of RxSO3.
+  ///
+  SOPHUS_FUNC Tangent log() const { return logAndTheta().tangent; }
+
+  /// As above, but also returns ``theta = |omega|``.
+  ///
+  SOPHUS_FUNC TangentAndTheta logAndTheta() const {
+    using std::log;
+
+    Scalar scale = quaternion().squaredNorm();
+    TangentAndTheta result;
+    result.tangent[3] = log(scale);
+    auto omega_and_theta = SO3<Scalar>(quaternion()).logAndTheta();
+    result.tangent.template head<3>() = omega_and_theta.tangent;
+    result.theta = omega_and_theta.theta;
+    return result;
+  }
+  /// Returns 3x3 matrix representation of the instance.
+  ///
+  /// For RxSO3, the matrix representation is an scaled orthogonal matrix ``sR``
+  /// with ``det(R)=s^3``, thus a scaled rotation matrix ``R``  with scale
+  /// ``s``.
+  ///
+  SOPHUS_FUNC Transformation matrix() const {
+    Transformation sR;
+
+    Scalar const vx_sq = quaternion().vec().x() * quaternion().vec().x();
+    Scalar const vy_sq = quaternion().vec().y() * quaternion().vec().y();
+    Scalar const vz_sq = quaternion().vec().z() * quaternion().vec().z();
+    Scalar const w_sq = quaternion().w() * quaternion().w();
+    Scalar const two_vx = Scalar(2) * quaternion().vec().x();
+    Scalar const two_vy = Scalar(2) * quaternion().vec().y();
+    Scalar const two_vz = Scalar(2) * quaternion().vec().z();
+    Scalar const two_vx_vy = two_vx * quaternion().vec().y();
+    Scalar const two_vx_vz = two_vx * quaternion().vec().z();
+    Scalar const two_vx_w = two_vx * quaternion().w();
+    Scalar const two_vy_vz = two_vy * quaternion().vec().z();
+    Scalar const two_vy_w = two_vy * quaternion().w();
+    Scalar const two_vz_w = two_vz * quaternion().w();
+
+    sR(0, 0) = vx_sq - vy_sq - vz_sq + w_sq;
+    sR(1, 0) = two_vx_vy + two_vz_w;
+    sR(2, 0) = two_vx_vz - two_vy_w;
+
+    sR(0, 1) = two_vx_vy - two_vz_w;
+    sR(1, 1) = -vx_sq + vy_sq - vz_sq + w_sq;
+    sR(2, 1) = two_vx_w + two_vy_vz;
+
+    sR(0, 2) = two_vx_vz + two_vy_w;
+    sR(1, 2) = -two_vx_w + two_vy_vz;
+    sR(2, 2) = -vx_sq - vy_sq + vz_sq + w_sq;
+    return sR;
   }
 
+  /// Assignment operator.
+  ///
+  SOPHUS_FUNC RxSO3Base& operator=(RxSO3Base const& other) = default;
 
-  /**
-   * \returns group inverse of instance
-   */
-  inline
-  const RxSO3Group<Scalar> inverse() const {
-    if(quaternion().squaredNorm() <= static_cast<Scalar>(0)) {
-      throw ScaleNotPositive();
-    }
-    return RxSO3Group<Scalar>(quaternion().inverse());
-  }
-
-  /**
-   * \brief Logarithmic map
-   *
-   * \returns tangent space representation (=rotation vector) of instance
-   *
-   * \see  log().
-   */
-  inline
-  const Tangent log() const {
-    return RxSO3Group<Scalar>::log(*this);
-  }
-
-  /**
-   * \returns 3x3 matrix representation of instance
-   *
-   * For RxSO3, the matrix representation is a scaled orthogonal
-   * matrix \f$ sR \f$ with \f$ det(sR)=s^3 \f$, thus a scaled rotation
-   * matrix \f$ R \f$  with scale s.
-   */
-  inline
-  const Transformation matrix() const {
-    //ToDO: implement this directly!
-    Scalar scale = quaternion().norm();
-    Quaternion<Scalar> norm_quad = quaternion();
-    norm_quad.coeffs() /= scale;
-    return scale*norm_quad.toRotationMatrix();
-  }
-
-  /**
-   * \brief Assignment operator
-   */
-  template<typename OtherDerived> inline
-  RxSO3GroupBase<Derived>& operator=
-  (const RxSO3GroupBase<OtherDerived> & other) {
-    quaternion() = other.quaternion();
+  /// Assignment-like operator from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC RxSO3Base<Derived>& operator=(
+      RxSO3Base<OtherDerived> const& other) {
+    quaternion_nonconst() = other.quaternion();
     return *this;
   }
 
-  /**
-   * \brief Group multiplication
-   * \see operator*=()
-   */
-  inline
-  const RxSO3Group<Scalar> operator*(const RxSO3Group<Scalar>& other) const {
-    RxSO3Group<Scalar> result(*this);
-    result *= other;
-    return result;
+  /// Group multiplication, which is rotation concatenation and scale
+  /// multiplication.
+  ///
+  /// Note: This function performs saturation for products close to zero in
+  /// order to ensure the class invariant.
+  ///
+  template <typename OtherDerived>
+  SOPHUS_FUNC RxSO3Product<OtherDerived> operator*(
+      RxSO3Base<OtherDerived> const& other) const {
+    using ResultT = ReturnScalar<OtherDerived>;
+    typename RxSO3Product<OtherDerived>::QuaternionType result_quaternion(
+        quaternion() * other.quaternion());
+
+    ResultT scale = result_quaternion.squaredNorm();
+    if (scale < Constants<ResultT>::epsilon()) {
+      SOPHUS_ENSURE(scale > ResultT(0), "Scale must be greater zero.");
+      /// Saturation to ensure class invariant.
+      result_quaternion.normalize();
+      result_quaternion.coeffs() *= sqrt(Constants<Scalar>::epsilon());
+    }
+    return RxSO3Product<OtherDerived>(result_quaternion);
   }
 
-  /**
-   * \brief Group action on \f$ \mathbf{R}^3 \f$
-   *
-   * \param p point \f$p \in \mathbf{R}^3 \f$
-   * \returns point \f$p' \in \mathbf{R}^3 \f$,
-   *          rotated and scaled version of \f$p\f$
-   *
-   * This function rotates and scales a point \f$ p \f$ in  \f$ \mathbf{R}^3 \f$
-   * by the RxSO3 transformation \f$sR\f$ (=rotation matrix)
-   * : \f$ p' = sR\cdot p \f$.
-   */
-  inline
-  const Point operator*(const Point & p) const {
-    //ToDO: implement this directly!
-    Scalar scale = quaternion().norm();
-    Quaternion<Scalar> norm_quad = quaternion();
-    norm_quad.coeffs() /= scale;
-    return scale*norm_quad._transformVector(p);
+  /// Group action on 3-points.
+  ///
+  /// This function rotates a 3 dimensional point ``p`` by the SO3 element
+  ///  ``bar_R_foo`` (= rotation matrix) and scales it by the scale factor
+  ///  ``s``:
+  ///
+  ///   ``p_bar = s * (bar_R_foo * p_foo)``.
+  ///
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 3>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
+    // Follows http:///eigen.tuxfamily.org/bz/show_bug.cgi?id=459
+    Scalar scale = quaternion().squaredNorm();
+    PointProduct<PointDerived> two_vec_cross_p = quaternion().vec().cross(p);
+    two_vec_cross_p += two_vec_cross_p;
+    return scale * p + (quaternion().w() * two_vec_cross_p +
+                        quaternion().vec().cross(two_vec_cross_p));
   }
 
-  /**
-   * \brief In-place group multiplication
-   * \see operator*=()
-   */
-  inline
-  void operator*=(const RxSO3Group<Scalar>& other) {
-    quaternion() *= other.quaternion();
+  /// Group action on homogeneous 3-points. See above for more details.
+  ///
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 4>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const auto rsp = *this * p.template head<3>();
+    return HomogeneousPointProduct<HPointDerived>(rsp(0), rsp(1), rsp(2), p(3));
   }
 
-  /**
-   * \brief Mutator of quaternion
-   */
-  EIGEN_STRONG_INLINE
-  QuaternionReference quaternion() {
-    return static_cast<Derived*>(this)->quaternion();
+  /// Group action on lines.
+  ///
+  /// This function rotates a parametrized line ``l(t) = o + t * d`` by the SO3
+  /// element ans scales it by the scale factor:
+  ///
+  /// Origin ``o`` is rotated and scaled
+  /// Direction ``d`` is rotated (preserving it's norm)
+  ///
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(),
+                (*this) * l.direction() / quaternion().squaredNorm());
   }
 
-  /**
-   * \brief Accessor of quaternion
-   */
-  EIGEN_STRONG_INLINE
-  ConstQuaternionReference quaternion() const {
-    return static_cast<const Derived*>(this)->quaternion();
+  /// In-place group multiplication. This method is only valid if the return
+  /// type of the multiplication is compatible with this SO3's Scalar type.
+  ///
+  /// Note: This function performs saturation for products close to zero in
+  /// order to ensure the class invariant.
+  ///
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC RxSO3Base<Derived>& operator*=(
+      RxSO3Base<OtherDerived> const& other) {
+    *static_cast<Derived*>(this) = *this * other;
+    return *this;
   }
 
-  /**
-   * \returns rotation matrix
-   */
-  inline
-  Transformation rotationMatrix() const {
-    Scalar scale = quaternion().norm();
-    Quaternion<Scalar> norm_quad = quaternion();
-    norm_quad.coeffs() /= scale;
+  /// Returns internal parameters of RxSO(3).
+  ///
+  /// It returns (q.imag[0], q.imag[1], q.imag[2], q.real), with q being the
+  /// quaternion.
+  ///
+  SOPHUS_FUNC Sophus::Vector<Scalar, num_parameters> params() const {
+    return quaternion().coeffs();
+  }
+
+  /// Sets non-zero quaternion
+  ///
+  /// Precondition: ``quat`` must not be close to zero.
+  SOPHUS_FUNC void setQuaternion(Eigen::Quaternion<Scalar> const& quat) {
+    SOPHUS_ENSURE(quat.squaredNorm() > Constants<Scalar>::epsilon() *
+                                           Constants<Scalar>::epsilon(),
+                  "Scale factor must be greater-equal epsilon.");
+    static_cast<Derived*>(this)->quaternion_nonconst() = quat;
+  }
+
+  /// Accessor of quaternion.
+  ///
+  SOPHUS_FUNC QuaternionType const& quaternion() const {
+    return static_cast<Derived const*>(this)->quaternion();
+  }
+
+  /// Returns rotation matrix.
+  ///
+  SOPHUS_FUNC Transformation rotationMatrix() const {
+    QuaternionTemporaryType norm_quad = quaternion();
+    norm_quad.normalize();
     return norm_quad.toRotationMatrix();
   }
 
-  /**
-   * \returns scale
-   */
-  EIGEN_STRONG_INLINE
-  const Scalar scale() const {
-    return quaternion().norm();
-  }
+  /// Returns scale.
+  ///
+  SOPHUS_FUNC
+  Scalar scale() const { return quaternion().squaredNorm(); }
 
-  /**
-   * \brief Setter of quaternion using rotation matrix, leaves scale untouched
-   *
-   * \param R a 3x3 rotation matrix
-   * \pre       the 3x3 matrix should be orthogonal and have a determinant of 1
-   */
-  inline
-  void setRotationMatrix(const Transformation & R) {
+  /// Setter of quaternion using rotation matrix ``R``, leaves scale as is.
+  ///
+  SOPHUS_FUNC void setRotationMatrix(Transformation const& R) {
+    using std::sqrt;
     Scalar saved_scale = scale();
-    quaternion() = R;
-    quaternion() *= saved_scale;
+    quaternion_nonconst() = R;
+    quaternion_nonconst().coeffs() *= sqrt(saved_scale);
   }
 
-  /**
-   * \brief Scale setter
-   */
-  EIGEN_STRONG_INLINE
-  void setScale(const Scalar & scale) {
-    quaternion().normalize();
-    quaternion() *= scale;
+  /// Sets scale and leaves rotation as is.
+  ///
+  /// Note: This function as a significant computational cost, since it has to
+  /// call the square root twice.
+  ///
+  SOPHUS_FUNC
+  void setScale(Scalar const& scale) {
+    using std::sqrt;
+    quaternion_nonconst().normalize();
+    quaternion_nonconst().coeffs() *= sqrt(scale);
   }
 
-  /**
-   * \brief Setter of quaternion using scaled rotation matrix
-   *
-   * \param sR a 3x3 scaled rotation matrix
-   * \pre        the 3x3 matrix should be "scaled orthogonal"
-   *             and have a positive determinant
-   */
-  inline
-  void setScaledRotationMatrix
-  (const Transformation & sR) {
-    Transformation squared_sR = sR*sR.transpose();
-    Scalar squared_scale
-        = static_cast<Scalar>(1./3.)
-        *(squared_sR(0,0)+squared_sR(1,1)+squared_sR(2,2));
-    if (squared_scale <= static_cast<Scalar>(0)) {
-      throw ScaleNotPositive();
-    }
-    Scalar scale = std::sqrt(squared_scale);
-    if (scale <= static_cast<Scalar>(0)) {
-      throw ScaleNotPositive();
-    }
-    quaternion() = sR/scale;
-    quaternion().coeffs() *= scale;
+  /// Setter of quaternion using scaled rotation matrix ``sR``.
+  ///
+  /// Precondition: The 3x3 matrix must be "scaled orthogonal"
+  ///               and have a positive determinant.
+  ///
+  SOPHUS_FUNC void setScaledRotationMatrix(Transformation const& sR) {
+    Transformation squared_sR = sR * sR.transpose();
+    Scalar squared_scale =
+        Scalar(1. / 3.) *
+        (squared_sR(0, 0) + squared_sR(1, 1) + squared_sR(2, 2));
+    SOPHUS_ENSURE(squared_scale >= Constants<Scalar>::epsilon() *
+                                       Constants<Scalar>::epsilon(),
+                  "Scale factor must be greater-equal epsilon.");
+    Scalar scale = sqrt(squared_scale);
+    quaternion_nonconst() = sR / scale;
+    quaternion_nonconst().coeffs() *= sqrt(scale);
   }
 
-  ////////////////////////////////////////////////////////////////////////////
-  // public static functions
-  ////////////////////////////////////////////////////////////////////////////
-
-  /**
-   * \param   b 4-vector representation of Lie algebra element
-   * \returns   derivative of Lie bracket
-   *
-   * This function returns \f$ \frac{\partial}{\partial a} [a, b]_{rxso3} \f$
-   * with \f$ [a, b]_{rxso3} \f$ being the lieBracket() of the Lie
-   * algebra rxso3.
-   *
-   * \see lieBracket()
-   */
-  inline static
-  const Adjoint d_lieBracketab_by_d_a(const Tangent & b) {
-    Adjoint res;
-    res.setZero();
-    res.template topLeftCorner<3,3>() = -SO3::hat(b.template head<3>());
-    return res;
+  /// Setter of SO(3) rotations, leaves scale as is.
+  ///
+  SOPHUS_FUNC void setSO3(SO3<Scalar> const& so3) {
+    using std::sqrt;
+    Scalar saved_scale = scale();
+    quaternion_nonconst() = so3.unit_quaternion();
+    quaternion_nonconst().coeffs() *= sqrt(saved_scale);
   }
 
-  /**
-   * \brief Group exponential
-   *
-   * \param a tangent space element
-   *          (rotation vector \f$ \omega \f$ and logarithm of scale)
-   * \returns corresponding element of the group RxSO3
-   *
-   * To be more specific, this function computes \f$ \exp(\widehat{a}) \f$
-   * with \f$ \exp(\cdot) \f$ being the matrix exponential
-   * and \f$ \widehat{\cdot} \f$ the hat()-operator of RxSO3.
-   *
-   * \see expAndTheta()
-   * \see hat()
-   * \see log()
-   */
-  inline static
-  const RxSO3Group<Scalar> exp(const Tangent & a) {
+  SOPHUS_FUNC SO3<Scalar> so3() const { return SO3<Scalar>(quaternion()); }
+
+ protected:
+  /// Mutator of quaternion is private to ensure class invariant.
+  ///
+  SOPHUS_FUNC QuaternionType& quaternion_nonconst() {
+    return static_cast<Derived*>(this)->quaternion_nonconst();
+  }
+};
+
+/// RxSO3 using storage; derived from RxSO3Base.
+template <class Scalar_, int Options>
+class RxSO3 : public RxSO3Base<RxSO3<Scalar_, Options>> {
+ public:
+  using Base = RxSO3Base<RxSO3<Scalar_, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+  using QuaternionMember = Eigen::Quaternion<Scalar, Options>;
+
+  /// ``Base`` is friend so quaternion_nonconst can be accessed from ``Base``.
+  friend class RxSO3Base<RxSO3<Scalar_, Options>>;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// Default constructor initializes quaternion to identity rotation and scale
+  /// to 1.
+  ///
+  SOPHUS_FUNC RxSO3()
+      : quaternion_(Scalar(1), Scalar(0), Scalar(0), Scalar(0)) {}
+
+  /// Copy constructor
+  ///
+  SOPHUS_FUNC RxSO3(RxSO3 const& other) = default;
+
+  /// Copy-like constructor from OtherDerived
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC RxSO3(RxSO3Base<OtherDerived> const& other)
+      : quaternion_(other.quaternion()) {}
+
+  /// Constructor from scaled rotation matrix
+  ///
+  /// Precondition: rotation matrix need to be scaled orthogonal with
+  /// determinant of ``s^3``.
+  ///
+  SOPHUS_FUNC explicit RxSO3(Transformation const& sR) {
+    this->setScaledRotationMatrix(sR);
+  }
+
+  /// Constructor from scale factor and rotation matrix ``R``.
+  ///
+  /// Precondition: Rotation matrix ``R`` must to be orthogonal with determinant
+  ///               of 1 and ``scale`` must not be close to zero.
+  ///
+  SOPHUS_FUNC RxSO3(Scalar const& scale, Transformation const& R)
+      : quaternion_(R) {
+    SOPHUS_ENSURE(scale >= Constants<Scalar>::epsilon(),
+                  "Scale factor must be greater-equal epsilon.");
+    using std::sqrt;
+    quaternion_.coeffs() *= sqrt(scale);
+  }
+
+  /// Constructor from scale factor and SO3
+  ///
+  /// Precondition: ``scale`` must not to be close to zero.
+  ///
+  SOPHUS_FUNC RxSO3(Scalar const& scale, SO3<Scalar> const& so3)
+      : quaternion_(so3.unit_quaternion()) {
+    SOPHUS_ENSURE(scale >= Constants<Scalar>::epsilon(),
+                  "Scale factor must be greater-equal epsilon.");
+    using std::sqrt;
+    quaternion_.coeffs() *= sqrt(scale);
+  }
+
+  /// Constructor from quaternion
+  ///
+  /// Precondition: quaternion must not be close to zero.
+  ///
+  template <class D>
+  SOPHUS_FUNC explicit RxSO3(Eigen::QuaternionBase<D> const& quat)
+      : quaternion_(quat) {
+    static_assert(std::is_same<typename D::Scalar, Scalar>::value,
+                  "must be same Scalar type.");
+    SOPHUS_ENSURE(quaternion_.squaredNorm() >= Constants<Scalar>::epsilon(),
+                  "Scale factor must be greater-equal epsilon.");
+  }
+
+  /// Accessor of quaternion.
+  ///
+  SOPHUS_FUNC QuaternionMember const& quaternion() const { return quaternion_; }
+
+  /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.
+  ///
+  SOPHUS_FUNC static Transformation Dxi_exp_x_matrix_at_0(int i) {
+    return generator(i);
+  }
+  /// Group exponential
+  ///
+  /// This functions takes in an element of tangent space (= rotation 3-vector
+  /// plus logarithm of scale) and returns the corresponding element of the
+  /// group RxSO3.
+  ///
+  /// To be more specific, thixs function computes ``expmat(hat(omega))``
+  /// with ``expmat(.)`` being the matrix exponential and ``hat(.)`` being the
+  /// hat()-operator of RSO3.
+  ///
+  SOPHUS_FUNC static RxSO3<Scalar> exp(Tangent const& a) {
     Scalar theta;
     return expAndTheta(a, &theta);
   }
 
-  /**
-   * \brief Group exponential and theta
-   *
-   * \param      a     tangent space element
-   *                   (rotation vector \f$ \omega \f$ and logarithm of scale )
-   * \param[out] theta angle of rotation \f$ \theta = |\omega| \f$
-   * \returns          corresponding element of the group RxSO3
-   *
-   * \see exp() for details
-   */
-  inline static
-  const RxSO3Group<Scalar> expAndTheta(const Tangent & a,
-                                       Scalar * theta) {
-    const Matrix<Scalar,3,1> & omega = a.template head<3>();
+  /// As above, but also returns ``theta = |omega|`` as out-parameter.
+  ///
+  /// Precondition: ``theta`` must not be ``nullptr``.
+  ///
+  SOPHUS_FUNC static RxSO3<Scalar> expAndTheta(Tangent const& a,
+                                               Scalar* theta) {
+    SOPHUS_ENSURE(theta != nullptr, "must not be nullptr.");
+    using std::exp;
+    using std::sqrt;
+
+    Vector3<Scalar> const omega = a.template head<3>();
     Scalar sigma = a[3];
-    Scalar scale = std::exp(sigma);
-    Quaternion<Scalar> quat
-        = SO3Group<Scalar>::expAndTheta(omega, theta).unit_quaternion();
-    quat.coeffs() *= scale;
-    return RxSO3Group<Scalar>(quat);
+    Scalar sqrt_scale = sqrt(exp(sigma));
+    Eigen::Quaternion<Scalar> quat =
+        SO3<Scalar>::expAndTheta(omega, theta).unit_quaternion();
+    quat.coeffs() *= sqrt_scale;
+    return RxSO3<Scalar>(quat);
   }
 
-  /**
-   * \brief Generators
-   *
-   * \pre \f$ i \in \{0,1,2,3\} \f$
-   * \returns \f$ i \f$th generator \f$ G_i \f$ of RxSO3
-   *
-   * The infinitesimal generators of RxSO3
-   * are \f$
-   *        G_0 = \left( \begin{array}{ccc}
-   *                          0&  0&  0& \\
-   *                          0&  0& -1& \\
-   *                          0&  1&  0&
-   *                     \end{array} \right),
-   *        G_1 = \left( \begin{array}{ccc}
-   *                          0&  0&  1& \\
-   *                          0&  0&  0& \\
-   *                         -1&  0&  0&
-   *                     \end{array} \right),
-   *        G_2 = \left( \begin{array}{ccc}
-   *                          0& -1&  0& \\
-   *                          1&  0&  0& \\
-   *                          0&  0&  0&
-   *                     \end{array} \right),
-   *        G_3 = \left( \begin{array}{ccc}
-   *                          1&  0&  0& \\
-   *                          0&  1&  0& \\
-   *                          0&  0&  1&
-   *                     \end{array} \right).
-   * \f$
-   * \see hat()
-   */
-  inline static
-  const Transformation generator(int i) {
-    if (i<0 || i>3) {
-      throw SophusException("i is not in range [0,3].");
-    }
+  /// Returns the ith infinitesimal generators of ``R+ x SO(3)``.
+  ///
+  /// The infinitesimal generators of RxSO3 are:
+  ///
+  /// ```
+  ///         |  0  0  0 |
+  ///   G_0 = |  0  0 -1 |
+  ///         |  0  1  0 |
+  ///
+  ///         |  0  0  1 |
+  ///   G_1 = |  0  0  0 |
+  ///         | -1  0  0 |
+  ///
+  ///         |  0 -1  0 |
+  ///   G_2 = |  1  0  0 |
+  ///         |  0  0  0 |
+  ///
+  ///         |  1  0  0 |
+  ///   G_2 = |  0  1  0 |
+  ///         |  0  0  1 |
+  /// ```
+  ///
+  /// Precondition: ``i`` must be 0, 1, 2 or 3.
+  ///
+  SOPHUS_FUNC static Transformation generator(int i) {
+    SOPHUS_ENSURE(i >= 0 && i <= 3, "i should be in range [0,3].");
     Tangent e;
     e.setZero();
-    e[i] = static_cast<Scalar>(1);
+    e[i] = Scalar(1);
     return hat(e);
   }
 
-  /**
-   * \brief hat-operator
-   *
-   * \param a 4-vector representation of Lie algebra element
-   * \returns 3x3-matrix representatin of Lie algebra element
-   *
-   * Formally, the hat-operator of RxSO3 is defined
-   * as \f$ \widehat{\cdot}: \mathbf{R}^4 \rightarrow \mathbf{R}^{3\times 3},
-   * \quad \widehat{a} = \sum_{i=0}^3 G_i a_i \f$
-   * with \f$ G_i \f$ being the ith infinitesial generator().
-   *
-   * \see generator()
-   * \see vee()
-   */
-  inline static
-  const Transformation hat(const Tangent & a) {
+  /// hat-operator
+  ///
+  /// It takes in the 4-vector representation ``a`` (= rotation vector plus
+  /// logarithm of scale) and  returns the corresponding matrix representation
+  /// of Lie algebra element.
+  ///
+  /// Formally, the hat()-operator of RxSO3 is defined as
+  ///
+  ///   ``hat(.): R^4 -> R^{3x3},  hat(a) = sum_i a_i * G_i``  (for i=0,1,2,3)
+  ///
+  /// with ``G_i`` being the ith infinitesimal generator of RxSO3.
+  ///
+  /// The corresponding inverse is the vee()-operator, see below.
+  ///
+  SOPHUS_FUNC static Transformation hat(Tangent const& a) {
     Transformation A;
-    A <<  a(3), -a(2),  a(1)
-        , a(2),  a(3), -a(0)
-        ,-a(1),  a(0),  a(3);
+    // clang-format off
+    A <<  a(3), -a(2),  a(1),
+          a(2),  a(3), -a(0),
+         -a(1),  a(0),  a(3);
+    // clang-format on
     return A;
   }
 
-  /**
-   * \brief Lie bracket
-   *
-   * \param a 4-vector representation of Lie algebra element
-   * \param b 4-vector representation of Lie algebra element
-   * \returns 4-vector representation of Lie algebra element
-   *
-   * It computes the bracket of RxSO3. To be more specific, it
-   * computes \f$ [a, 2]_{rxso3}
-   * := [\widehat{a}, \widehat{b}]^\vee \f$
-   * with \f$ [A,B] = AB-BA \f$ being the matrix
-   * commutator, \f$ \widehat{\cdot} \f$ the
-   * hat()-operator and \f$ (\cdot)^\vee \f$ the vee()-operator of RxSO3.
-   *
-   * \see hat()
-   * \see vee()
-   */
-  inline static
-  const Tangent lieBracket(const Tangent & a,
-                           const Tangent & b) {
-    const Matrix<Scalar,3,1> & omega1 = a.template head<3>();
-    const Matrix<Scalar,3,1> & omega2 = b.template head<3>();
-    Matrix<Scalar,4,1> res;
+  /// Lie bracket
+  ///
+  /// It computes the Lie bracket of RxSO(3). To be more specific, it computes
+  ///
+  ///   ``[omega_1, omega_2]_rxso3 := vee([hat(omega_1), hat(omega_2)])``
+  ///
+  /// with ``[A,B] := AB-BA`` being the matrix commutator, ``hat(.)`` the
+  /// hat()-operator and ``vee(.)`` the vee()-operator of RxSO3.
+  ///
+  SOPHUS_FUNC static Tangent lieBracket(Tangent const& a, Tangent const& b) {
+    Vector3<Scalar> const omega1 = a.template head<3>();
+    Vector3<Scalar> const omega2 = b.template head<3>();
+    Vector4<Scalar> res;
     res.template head<3>() = omega1.cross(omega2);
-    res[3] = static_cast<Scalar>(0);
+    res[3] = Scalar(0);
     return res;
   }
 
-  /**
-   * \brief Logarithmic map
-   *
-   * \param other element of the group RxSO3
-   * \returns     corresponding tangent space element
-   *              (rotation vector \f$ \omega \f$ and logarithm of scale)
-   *
-   * Computes the logarithmic, the inverse of the group exponential.
-   * To be specific, this function computes \f$ \log({\cdot})^\vee \f$
-   * with \f$ \vee(\cdot) \f$ being the matrix logarithm
-   * and \f$ \vee{\cdot} \f$ the vee()-operator of RxSO3.
-   *
-   * \see exp()
-   * \see logAndTheta()
-   * \see vee()
-   */
-  inline static
-  const Tangent log(const RxSO3Group<Scalar> & other) {
-    Scalar theta;
-    return logAndTheta(other, &theta);
+  /// Draw uniform sample from RxSO(3) manifold.
+  ///
+  /// The scale factor is drawn uniformly in log2-space from [-1, 1],
+  /// hence the scale is in [0.5, 2].
+  ///
+  template <class UniformRandomBitGenerator>
+  static RxSO3 sampleUniform(UniformRandomBitGenerator& generator) {
+    std::uniform_real_distribution<Scalar> uniform(Scalar(-1), Scalar(1));
+    using std::exp2;
+    return RxSO3(exp2(uniform(generator)),
+                 SO3<Scalar>::sampleUniform(generator));
   }
 
-  /**
-   * \brief Logarithmic map and theta
-   *
-   * \param      other element of the group RxSO3
-   * \param[out] theta angle of rotation \f$ \theta = |\omega| \f$
-   * \returns          corresponding tangent space element
-   *                   (rotation vector \f$ \omega \f$ and logarithm of scale)
-   *
-   * \see log() for details
-   */
-  inline static
-  const Tangent logAndTheta(const RxSO3Group<Scalar> & other,
-                            Scalar * theta) {
-    const Scalar & scale = other.quaternion().norm();
-    Tangent omega_sigma;
-    omega_sigma[3] = std::log(scale);
-    omega_sigma.template head<3>()
-        = SO3Group<Scalar>::logAndTheta(SO3Group<Scalar>(other.quaternion()),
-                                        theta);
-    return omega_sigma;
+  /// vee-operator
+  ///
+  /// It takes the 3x3-matrix representation ``Omega`` and maps it to the
+  /// corresponding vector representation of Lie algebra.
+  ///
+  /// This is the inverse of the hat()-operator, see above.
+  ///
+  /// Precondition: ``Omega`` must have the following structure:
+  ///
+  ///                |  d -c  b |
+  ///                |  c  d -a |
+  ///                | -b  a  d |
+  ///
+  SOPHUS_FUNC static Tangent vee(Transformation const& Omega) {
+    using std::abs;
+    return Tangent(Omega(2, 1), Omega(0, 2), Omega(1, 0), Omega(0, 0));
   }
 
-  /**
-   * \brief vee-operator
-   *
-   * \param Omega 3x3-matrix representation of Lie algebra element
-   * \returns     4-vector representatin of Lie algebra element
-   *
-   * This is the inverse of the hat()-operator.
-   *
-   * \see hat()
-   */
-  inline static
-  const Tangent vee(const Transformation & Omega) {
-    return Tangent( static_cast<Scalar>(0.5) * (Omega(2,1) - Omega(1,2)),
-                    static_cast<Scalar>(0.5) * (Omega(0,2) - Omega(2,0)),
-                    static_cast<Scalar>(0.5) * (Omega(1,0) - Omega(0,1)),
-                    static_cast<Scalar>(1./3.)
-                    * (Omega(0,0) + Omega(1,1) + Omega(2,2)) );
-  }
+ protected:
+  SOPHUS_FUNC QuaternionMember& quaternion_nonconst() { return quaternion_; }
+
+  QuaternionMember quaternion_;
 };
 
-/**
- * \brief RxSO3 default type - Constructors and default storage for RxSO3 Type
- */
-template<typename _Scalar, int _Options>
-class RxSO3Group : public RxSO3GroupBase<RxSO3Group<_Scalar,_Options> > {
-  typedef RxSO3GroupBase<RxSO3Group<_Scalar,_Options> > Base;
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<SO3Group<_Scalar,_Options> >
-  ::Scalar Scalar;
-  /** \brief quaternion reference type */
-  typedef typename internal::traits<SO3Group<_Scalar,_Options> >
-  ::QuaternionType & QuaternionReference;
-  /** \brief quaternion const reference type */
-  typedef const typename internal::traits<SO3Group<_Scalar,_Options> >
-  ::QuaternionType & ConstQuaternionReference;
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-  /**
-   * \brief Default constructor
-   *
-   * Initialize Quaternion to identity rotation and scale.
-   */
-  inline RxSO3Group()
-    : quaternion_(static_cast<Scalar>(1), static_cast<Scalar>(0),
-                  static_cast<Scalar>(0), static_cast<Scalar>(0)) {
-  }
-
-  /**
-   * \brief Copy constructor
-   */
-  template<typename OtherDerived> inline
-  RxSO3Group(const RxSO3GroupBase<OtherDerived> & other)
-    : quaternion_(other.quaternion()) {
-  }
-
-  /**
-   * \brief Constructor from scaled rotation matrix
-   *
-   * \pre matrix need to be "scaled orthogonal" with positive determinant
-   */
-  inline explicit
-  RxSO3Group(const Transformation & sR) {
-    setScaledRotationMatrix(sR);
-  }
-
-  /**
-   * \brief Constructor from scale factor and rotation matrix
-   *
-   * \pre rotation matrix need to be orthogonal with determinant of 1
-   * \pre scale need to be not zero
-   */
-  inline
-  RxSO3Group(const Scalar & scale, const Transformation & R)
-    : quaternion_(R) {
-    if(scale <= static_cast<Scalar>(0)) {
-      throw ScaleNotPositive();
-    }
-    quaternion_.normalize();
-    quaternion_.coeffs() *= scale;
-  }
-
-  /**
-   * \brief Constructor from scale factor and SO3
-   *
-   * \pre scale need to be not zero
-   */
-  inline
-  RxSO3Group(const Scalar & scale, const SO3Group<Scalar> & so3)
-    : quaternion_(so3.unit_quaternion()) {
-    if (scale <= static_cast<Scalar>(0)) {
-      throw ScaleNotPositive();
-    }
-    quaternion_.normalize();
-    quaternion_.coeffs() *= scale;
-  }
-
-  /**
-   * \brief Constructor from quaternion
-   *
-   * \pre quaternion must not be zero
-   */
-  inline explicit
-  RxSO3Group(const Quaternion<Scalar> & quat) : quaternion_(quat) {
-    if(quaternion_.squaredNorm() <= SophusConstants<Scalar>::epsilon()) {
-      throw ScaleNotPositive();
-    }
-  }
-
-  /**
-   * \brief Mutator of quaternion
-   */
-  EIGEN_STRONG_INLINE
-  QuaternionReference quaternion() {
-    return quaternion_;
-  }
-
-  /**
-   * \brief Accessor of quaternion
-   */
-  EIGEN_STRONG_INLINE
-  ConstQuaternionReference quaternion() const {
-    return quaternion_;
-  }
-
-protected:
-  Quaternion<Scalar> quaternion_;
-};
-
-} // end namespace
-
+}  // namespace Sophus
 
 namespace Eigen {
-/**
- * \brief Specialisation of Eigen::Map for RxSO3GroupBase
- *
- * Allows us to wrap RxSO3 Objects around POD array
- * (e.g. external c style quaternion)
- */
-template<typename _Scalar, int _Options>
-class Map<Sophus::RxSO3Group<_Scalar>, _Options>
-    : public Sophus::RxSO3GroupBase<
-    Map<Sophus::RxSO3Group<_Scalar>,_Options> > {
-  typedef Sophus::RxSO3GroupBase<Map<Sophus::RxSO3Group<_Scalar>, _Options> >
-  Base;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief quaternion reference type */
-  typedef typename internal::traits<Map>::QuaternionType &
-  QuaternionReference;
-  /** \brief quaternion const reference type */
-  typedef const typename internal::traits<Map>::QuaternionType &
-  ConstQuaternionReference;
+/// Specialization of Eigen::Map for ``RxSO3``; derived from RxSO3Base
+///
+/// Allows us to wrap RxSO3 objects around POD array (e.g. external c style
+/// quaternion).
+template <class Scalar_, int Options>
+class Map<Sophus::RxSO3<Scalar_>, Options>
+    : public Sophus::RxSO3Base<Map<Sophus::RxSO3<Scalar_>, Options>> {
+ public:
+  using Base = Sophus::RxSO3Base<Map<Sophus::RxSO3<Scalar_>, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
+  /// ``Base`` is friend so quaternion_nonconst can be accessed from ``Base``.
+  friend class Sophus::RxSO3Base<Map<Sophus::RxSO3<Scalar_>, Options>>;
 
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
+  // LCOV_EXCL_START
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  // LCOV_EXCL_STOP
+
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(Scalar* coeffs) : quaternion_(coeffs) {
-  }
+  SOPHUS_FUNC Map(Scalar* coeffs) : quaternion_(coeffs) {}
 
-  /**
-   * \brief Mutator of quaternion
-   */
-  EIGEN_STRONG_INLINE
-  QuaternionReference quaternion() {
+  /// Accessor of quaternion.
+  ///
+  SOPHUS_FUNC
+  Map<Eigen::Quaternion<Scalar>, Options> const& quaternion() const {
     return quaternion_;
   }
 
-  /**
-   * \brief Accessor of quaternion
-   */
-  EIGEN_STRONG_INLINE
-  ConstQuaternionReference quaternion() const {
+ protected:
+  SOPHUS_FUNC Map<Eigen::Quaternion<Scalar>, Options>& quaternion_nonconst() {
     return quaternion_;
   }
 
-protected:
-  Map<Quaternion<Scalar>,_Options> quaternion_;
+  Map<Eigen::Quaternion<Scalar>, Options> quaternion_;
 };
 
-/**
- * \brief Specialisation of Eigen::Map for const RxSO3GroupBase
- *
- * Allows us to wrap RxSO3 Objects around POD array
- * (e.g. external c style quaternion)
- */
-template<typename _Scalar, int _Options>
-class Map<const Sophus::RxSO3Group<_Scalar>, _Options>
-    : public Sophus::RxSO3GroupBase<
-    Map<const Sophus::RxSO3Group<_Scalar>, _Options> > {
-  typedef Sophus::RxSO3GroupBase<
-  Map<const Sophus::RxSO3Group<_Scalar>, _Options> > Base;
+/// Specialization of Eigen::Map for ``RxSO3 const``; derived from RxSO3Base.
+///
+/// Allows us to wrap RxSO3 objects around POD array (e.g. external c style
+/// quaternion).
+template <class Scalar_, int Options>
+class Map<Sophus::RxSO3<Scalar_> const, Options>
+    : public Sophus::RxSO3Base<Map<Sophus::RxSO3<Scalar_> const, Options>> {
+ public:
+  using Base = Sophus::RxSO3Base<Map<Sophus::RxSO3<Scalar_> const, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief quaternion const reference type */
-  typedef const typename internal::traits<Map>::QuaternionType &
-  ConstQuaternionReference;
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(const Scalar* coeffs) : quaternion_(coeffs) {
-  }
+  SOPHUS_FUNC
+  Map(Scalar const* coeffs) : quaternion_(coeffs) {}
 
-  /**
-   * \brief Accessor of unit quaternion
-   *
-   * No direct write access is given to ensure the quaternion stays normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstQuaternionReference quaternion() const {
+  /// Accessor of quaternion.
+  ///
+  SOPHUS_FUNC
+  Map<Eigen::Quaternion<Scalar> const, Options> const& quaternion() const {
     return quaternion_;
   }
 
-protected:
-  const Map<const Quaternion<Scalar>,_Options> quaternion_;
+ protected:
+  Map<Eigen::Quaternion<Scalar> const, Options> const quaternion_;
 };
+}  // namespace Eigen
 
-}
-
-#endif // SOPHUS_RXSO3_HPP
+#endif  /// SOPHUS_RXSO3_HPP

--- a/thirdparty/sophus/se2.hpp
+++ b/thirdparty/sophus/se2.hpp
@@ -1,907 +1,840 @@
-// This file is part of Sophus.
-//
-// Copyright 2012-2013 Hauke Strasdat
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal in the Software without restriction, including without limitation the
-// rights  to use, copy, modify, merge, publish, distribute, sublicense, and/or
-// sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
+/// @file
+/// Special Euclidean group SE(2) - rotation and translation in 2d.
 
 #ifndef SOPHUS_SE2_HPP
 #define SOPHUS_SE2_HPP
 
 #include "so2.hpp"
 
-////////////////////////////////////////////////////////////////////////////
-// Forward Declarations / typedefs
-////////////////////////////////////////////////////////////////////////////
-
 namespace Sophus {
-template<typename _Scalar, int _Options=0> class SE2Group;
-typedef SE2Group<double> SE2 EIGEN_DEPRECATED;
-typedef SE2Group<double> SE2d; /**< double precision SE2 */
-typedef SE2Group<float> SE2f;  /**< single precision SE2 */
-}
-
-////////////////////////////////////////////////////////////////////////////
-// Eigen Traits (For querying derived types in CRTP hierarchy)
-////////////////////////////////////////////////////////////////////////////
+template <class Scalar_, int Options = 0>
+class SE2;
+using SE2d = SE2<double>;
+using SE2f = SE2<float>;
+}  // namespace Sophus
 
 namespace Eigen {
 namespace internal {
 
-template<typename _Scalar, int _Options>
-struct traits<Sophus::SE2Group<_Scalar,_Options> > {
-  typedef _Scalar Scalar;
-  typedef Matrix<Scalar,2,1> TranslationType;
-  typedef Sophus::SO2Group<Scalar> SO2Type;
+template <class Scalar_, int Options>
+struct traits<Sophus::SE2<Scalar_, Options>> {
+  using Scalar = Scalar_;
+  using TranslationType = Sophus::Vector2<Scalar, Options>;
+  using SO2Type = Sophus::SO2<Scalar, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<Sophus::SE2Group<_Scalar>, _Options> >
-    : traits<Sophus::SE2Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<Matrix<Scalar,2,1>,_Options> TranslationType;
-  typedef Map<Sophus::SO2Group<Scalar>,_Options> SO2Type;
+template <class Scalar_, int Options>
+struct traits<Map<Sophus::SE2<Scalar_>, Options>>
+    : traits<Sophus::SE2<Scalar_, Options>> {
+  using Scalar = Scalar_;
+  using TranslationType = Map<Sophus::Vector2<Scalar>, Options>;
+  using SO2Type = Map<Sophus::SO2<Scalar>, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<const Sophus::SE2Group<_Scalar>, _Options> >
-    : traits<const Sophus::SE2Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<const Matrix<Scalar,2,1>,_Options> TranslationType;
-  typedef Map<const Sophus::SO2Group<Scalar>,_Options> SO2Type;
+template <class Scalar_, int Options>
+struct traits<Map<Sophus::SE2<Scalar_> const, Options>>
+    : traits<Sophus::SE2<Scalar_, Options> const> {
+  using Scalar = Scalar_;
+  using TranslationType = Map<Sophus::Vector2<Scalar> const, Options>;
+  using SO2Type = Map<Sophus::SO2<Scalar> const, Options>;
 };
-
-}
-}
+}  // namespace internal
+}  // namespace Eigen
 
 namespace Sophus {
-using namespace Eigen;
-using namespace std;
 
-/**
- * \brief SE2 base type - implements SE2 class but is storage agnostic
- *
- * [add more detailed description/tutorial]
- */
-template<typename Derived>
-class SE2GroupBase {
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
-  /** \brief translation reference type */
-  typedef typename internal::traits<Derived>::TranslationType &
-  TranslationReference;
-  /** \brief translation const reference type */
-  typedef const typename internal::traits<Derived>::TranslationType &
-  ConstTranslationReference;
-  /** \brief SO2 reference type */
-  typedef typename internal::traits<Derived>::SO2Type &
-  SO2Reference;
-  /** \brief SO2 type */
-  typedef const typename internal::traits<Derived>::SO2Type &
-  ConstSO2Reference;
+/// SE2 base type - implements SE2 class but is storage agnostic.
+///
+/// SE(2) is the group of rotations  and translation in 2d. It is the
+/// semi-direct product of SO(2) and the 2d Euclidean vector space.  The class
+/// is represented using a composition of SO2Group  for rotation and a 2-vector
+/// for translation.
+///
+/// SE(2) is neither compact, nor a commutative group.
+///
+/// See SO2Group for more details of the rotation representation in 2d.
+///
+template <class Derived>
+class SE2Base {
+ public:
+  using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
+  using TranslationType =
+      typename Eigen::internal::traits<Derived>::TranslationType;
+  using SO2Type = typename Eigen::internal::traits<Derived>::SO2Type;
 
-  /** \brief degree of freedom of group
-    *        (two for translation, one for in-plane rotation) */
-  static const int DoF = 3;
-  /** \brief number of internal parameters used
-    *        (unit complex number for rotation + translation 2-vector) */
-  static const int num_parameters = 4;
-  /** \brief group transformations are NxN matrices */
-  static const int N = 3;
-  /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
-  /** \brief point type */
-  typedef Matrix<Scalar,2,1> Point;
-  /** \brief tangent vector type */
-  typedef Matrix<Scalar,DoF,1> Tangent;
-  /** \brief adjoint transformation type */
-  typedef Matrix<Scalar,DoF,DoF> Adjoint;
+  /// Degrees of freedom of manifold, number of dimensions in tangent space
+  /// (two for translation, three for rotation).
+  static int constexpr DoF = 3;
+  /// Number of internal parameters used (tuple for complex, two for
+  /// translation).
+  static int constexpr num_parameters = 4;
+  /// Group transformations are 3x3 matrices.
+  static int constexpr N = 3;
+  using Transformation = Matrix<Scalar, N, N>;
+  using Point = Vector2<Scalar>;
+  using HomogeneousPoint = Vector3<Scalar>;
+  using Line = ParametrizedLine2<Scalar>;
+  using Tangent = Vector<Scalar, DoF>;
+  using Adjoint = Matrix<Scalar, DoF, DoF>;
 
-  /**
-   * \brief Adjoint transformation
-   *
-   * This function return the adjoint transformation \f$ Ad \f$ of the
-   * group instance \f$ A \f$  such that for all \f$ x \f$
-   * it holds that \f$ \widehat{Ad_A\cdot x} = A\widehat{x}A^{-1} \f$
-   * with \f$\ \widehat{\cdot} \f$ being the hat()-operator.
-   */
-  inline
-  const Adjoint Adj() const {
-    const Matrix<Scalar,2,2> & R = so2().matrix();
+  /// For binary operations the return type is determined with the
+  /// ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  /// types, as well as other compatible scalar types such as Ceres::Jet and
+  /// double scalars with SE2 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
+
+  template <typename OtherDerived>
+  using SE2Product = SE2<ReturnScalar<OtherDerived>>;
+
+  template <typename PointDerived>
+  using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector3<ReturnScalar<HPointDerived>>;
+
+  /// Adjoint transformation
+  ///
+  /// This function return the adjoint transformation ``Ad`` of the group
+  /// element ``A`` such that for all ``x`` it holds that
+  /// ``hat(Ad_A * x) = A * hat(x) A^{-1}``. See hat-operator below.
+  ///
+  SOPHUS_FUNC Adjoint Adj() const {
+    Matrix<Scalar, 2, 2> const& R = so2().matrix();
     Transformation res;
     res.setIdentity();
-    res.template topLeftCorner<2,2>() = R;
-    res(0,2) =  translation()[1];
-    res(1,2) = -translation()[0];
+    res.template topLeftCorner<2, 2>() = R;
+    res(0, 2) = translation()[1];
+    res(1, 2) = -translation()[0];
     return res;
   }
 
-  /**
-   * \returns copy of instance casted to NewScalarType
-   */
-  template<typename NewScalarType>
-  inline SE2Group<NewScalarType> cast() const {
-    return
-        SE2Group<NewScalarType>(so2().template cast<NewScalarType>(),
-                                translation().template cast<NewScalarType>() );
+  /// Returns copy of instance casted to NewScalarType.
+  ///
+  template <class NewScalarType>
+  SOPHUS_FUNC SE2<NewScalarType> cast() const {
+    return SE2<NewScalarType>(so2().template cast<NewScalarType>(),
+                              translation().template cast<NewScalarType>());
   }
 
-  /**
-   * \brief Fast group multiplication
-   *
-   * This method is a fast version of operator*=(), since it does not perform
-   * normalization. It is up to the user to call normalize() once in a while.
-   *
-   * \see operator*=()
-   */
-  inline
-  void fastMultiply(const SE2Group<Scalar>& other) {
-    translation() += so2()*(other.translation());
-    so2().fastMultiply(other.so2());
+  /// Returns derivative of  this * exp(x)  wrt x at x=0.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, num_parameters, DoF> Dx_this_mul_exp_x_at_0()
+      const {
+    Matrix<Scalar, num_parameters, DoF> J;
+    Sophus::Vector2<Scalar> const c = unit_complex();
+    Scalar o(0);
+    J(0, 0) = o;
+    J(0, 1) = o;
+    J(0, 2) = -c[1];
+    J(1, 0) = o;
+    J(1, 1) = o;
+    J(1, 2) = c[0];
+    J(2, 0) = c[0];
+    J(2, 1) = -c[1];
+    J(2, 2) = o;
+    J(3, 0) = c[1];
+    J(3, 1) = c[0];
+    J(3, 2) = o;
+    return J;
   }
 
-  /**
-   * \returns Group inverse of instance
-   */
-  inline
-  const SE2Group<Scalar> inverse() const {
-    const SO2Group<Scalar> invR = so2().inverse();
-    return SE2Group<Scalar>(invR, invR*(translation()
-                                        *static_cast<Scalar>(-1) ) );
+  /// Returns group inverse.
+  ///
+  SOPHUS_FUNC SE2<Scalar> inverse() const {
+    SO2<Scalar> const invR = so2().inverse();
+    return SE2<Scalar>(invR, invR * (translation() * Scalar(-1)));
   }
 
-  /**
-   * \brief Logarithmic map
-   *
-   * \returns tangent space representation
-   *          (translational part and rotation angle) of instance
-   *
-   * \see  log().
-   */
-  inline
-  const Tangent log() const {
-    return log(*this);
+  /// Logarithmic map
+  ///
+  /// Computes the logarithm, the inverse of the group exponential which maps
+  /// element of the group (rigid body transformations) to elements of the
+  /// tangent space (twist).
+  ///
+  /// To be specific, this function computes ``vee(logmat(.))`` with
+  /// ``logmat(.)`` being the matrix logarithm and ``vee(.)`` the vee-operator
+  /// of SE(2).
+  ///
+  SOPHUS_FUNC Tangent log() const {
+    using std::abs;
+
+    Tangent upsilon_theta;
+    Scalar theta = so2().log();
+    upsilon_theta[2] = theta;
+    Scalar halftheta = Scalar(0.5) * theta;
+    Scalar halftheta_by_tan_of_halftheta;
+
+    Vector2<Scalar> z = so2().unit_complex();
+    Scalar real_minus_one = z.x() - Scalar(1.);
+    if (abs(real_minus_one) < Constants<Scalar>::epsilon()) {
+      halftheta_by_tan_of_halftheta =
+          Scalar(1.) - Scalar(1. / 12) * theta * theta;
+    } else {
+      halftheta_by_tan_of_halftheta = -(halftheta * z.y()) / (real_minus_one);
+    }
+    Matrix<Scalar, 2, 2> V_inv;
+    V_inv << halftheta_by_tan_of_halftheta, halftheta, -halftheta,
+        halftheta_by_tan_of_halftheta;
+    upsilon_theta.template head<2>() = V_inv * translation();
+    return upsilon_theta;
   }
 
-  /**
-   * \brief Normalize SO2 element
-   *
-   * It re-normalizes the SO2 element. This method only needs to
-   * be called in conjunction with fastMultiply() or data() write access.
-   */
-  inline
-  void normalize() {
-    so2().normalize();
-  }
+  /// Normalize SO2 element
+  ///
+  /// It re-normalizes the SO2 element.
+  ///
+  SOPHUS_FUNC void normalize() { so2().normalize(); }
 
-  /**
-   * \returns 3x3 matrix representation of instance
-   */
-  inline
-  const Transformation matrix() const {
+  /// Returns 3x3 matrix representation of the instance.
+  ///
+  /// It has the following form:
+  ///
+  ///   | R t |
+  ///   | o 1 |
+  ///
+  /// where ``R`` is a 2x2 rotation matrix, ``t`` a translation 2-vector and
+  /// ``o`` a 2-column vector of zeros.
+  ///
+  SOPHUS_FUNC Transformation matrix() const {
     Transformation homogenious_matrix;
-    homogenious_matrix.setIdentity();
-    homogenious_matrix.block(0,0,2,2) = rotationMatrix();
-    homogenious_matrix.col(2).head(2) = translation();
+    homogenious_matrix.template topLeftCorner<2, 3>() = matrix2x3();
+    homogenious_matrix.row(2) =
+        Matrix<Scalar, 1, 3>(Scalar(0), Scalar(0), Scalar(1));
     return homogenious_matrix;
   }
 
-  /**
-   * \returns 2x3 matrix representation of instance
-   *
-   * It returns the three first row of matrix().
-   */
-  inline
-  const Matrix<Scalar,2,3> matrix2x3() const {
-    Matrix<Scalar,2,3> matrix;
-    matrix.block(0,0,2,2) = rotationMatrix();
+  /// Returns the significant first two rows of the matrix above.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, 2, 3> matrix2x3() const {
+    Matrix<Scalar, 2, 3> matrix;
+    matrix.template topLeftCorner<2, 2>() = rotationMatrix();
     matrix.col(2) = translation();
     return matrix;
   }
 
-  /**
-   * \brief Assignment operator
-   */
-  template<typename OtherDerived> inline
-  SE2GroupBase<Derived>& operator= (const SE2GroupBase<OtherDerived> & other) {
+  /// Assignment operator.
+  ///
+  SOPHUS_FUNC SE2Base& operator=(SE2Base const& other) = default;
+
+  /// Assignment-like operator from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC SE2Base<Derived>& operator=(SE2Base<OtherDerived> const& other) {
     so2() = other.so2();
     translation() = other.translation();
     return *this;
   }
 
-  /**
-   * \brief Group multiplication
-   * \see operator*=()
-   */
-  inline
-  const SE2Group<Scalar> operator*(const SE2Group<Scalar>& other) const {
-    SE2Group<Scalar> result(*this);
-    result *= other;
-    return result;
+  /// Group multiplication, which is rotation concatenation.
+  ///
+  template <typename OtherDerived>
+  SOPHUS_FUNC SE2Product<OtherDerived> operator*(
+      SE2Base<OtherDerived> const& other) const {
+    return SE2Product<OtherDerived>(
+        so2() * other.so2(), translation() + so2() * other.translation());
   }
 
-  /**
-   * \brief Group action on \f$ \mathbf{R}^2 \f$
-   *
-   * \param p point \f$p \in \mathbf{R}^2 \f$
-   * \returns point \f$p' \in \mathbf{R}^2 \f$,
-   *          rotated and translated version of \f$p\f$
-   *
-   * This function rotates and translates point \f$ p \f$
-   * in \f$ \mathbf{R}^2 \f$ by the SE2 transformation \f$R,t\f$
-   * (=rotation matrix, translation vector): \f$ p' = R\cdot p + t \f$.
-   */
-  inline
-  const Point operator*(const Point & p) const {
-    return so2()*p + translation();
+  /// Group action on 2-points.
+  ///
+  /// This function rotates and translates a two dimensional point ``p`` by the
+  /// SE(2) element ``bar_T_foo = (bar_R_foo, t_bar)`` (= rigid body
+  /// transformation):
+  ///
+  ///   ``p_bar = bar_R_foo * p_foo + t_bar``.
+  ///
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 2>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
+    return so2() * p + translation();
   }
 
-  /**
-   * \brief In-place group multiplication
-   *
-   * \see fastMultiply()
-   * \see operator*()
-   */
-  inline
-  void operator*=(const SE2Group<Scalar>& other) {
-    fastMultiply(other);
-    normalize();
+  /// Group action on homogeneous 2-points. See above for more details.
+  ///
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 3>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const PointProduct<HPointDerived> tp =
+        so2() * p.template head<2>() + p(2) * translation();
+    return HomogeneousPointProduct<HPointDerived>(tp(0), tp(1), p(2));
   }
 
+  /// Group action on lines.
+  ///
+  /// This function rotates and translates a parametrized line
+  /// ``l(t) = o + t * d`` by the SE(2) element:
+  ///
+  /// Origin ``o`` is rotated and translated using SE(2) action
+  /// Direction ``d`` is rotated using SO(2) action
+  ///
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), so2() * l.direction());
+  }
 
-  /**
-   * \returns Rotation matrix
-   */
-  inline
-  const Matrix<Scalar,2,2> rotationMatrix() const {
+  /// In-place group multiplication. This method is only valid if the return
+  /// type of the multiplication is compatible with this SO2's Scalar type.
+  ///
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC SE2Base<Derived>& operator*=(SE2Base<OtherDerived> const& other) {
+    *static_cast<Derived*>(this) = *this * other;
+    return *this;
+  }
+
+  /// Returns internal parameters of SE(2).
+  ///
+  /// It returns (c[0], c[1], t[0], t[1]),
+  /// with c being the unit complex number, t the translation 3-vector.
+  ///
+  SOPHUS_FUNC Sophus::Vector<Scalar, num_parameters> params() const {
+    Sophus::Vector<Scalar, num_parameters> p;
+    p << so2().params(), translation();
+    return p;
+  }
+
+  /// Returns rotation matrix.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, 2, 2> rotationMatrix() const {
     return so2().matrix();
   }
 
-  /**
-   * \brief Setter of internal unit complex number representation
-   *
-   * \param complex
-   * \pre   the complex number must not be zero
-   *
-   * The complex number is normalized to unit length.
-   */
-  inline
-  void setComplex(const Matrix<Scalar,2,1> & complex) {
+  /// Takes in complex number, and normalizes it.
+  ///
+  /// Precondition: The complex number must not be close to zero.
+  ///
+  SOPHUS_FUNC void setComplex(Sophus::Vector2<Scalar> const& complex) {
     return so2().setComplex(complex);
   }
 
-  /**
-   * \brief Setter of unit complex number using rotation matrix
-   *
-   * \param R a 2x2 matrix
-   * \pre     the 2x2 matrix should be orthogonal and have a determinant of 1
-   */
-  inline
-  void setRotationMatrix(const Matrix<Scalar,2,2> & R) {
-    so2().setComplex(static_cast<Scalar>(0.5)*(R(0,0)+R(1,1)),
-                     static_cast<Scalar>(0.5)*(R(1,0)-R(0,1)));
+  /// Sets ``so3`` using ``rotation_matrix``.
+  ///
+  /// Precondition: ``R`` must be orthogonal and ``det(R)=1``.
+  ///
+  SOPHUS_FUNC void setRotationMatrix(Matrix<Scalar, 2, 2> const& R) {
+    SOPHUS_ENSURE(isOrthogonal(R), "R is not orthogonal:\n %", R);
+    SOPHUS_ENSURE(R.determinant() > Scalar(0), "det(R) is not positive: %",
+                  R.determinant());
+    typename SO2Type::ComplexTemporaryType const complex(
+        Scalar(0.5) * (R(0, 0) + R(1, 1)), Scalar(0.5) * (R(1, 0) - R(0, 1)));
+    so2().setComplex(complex);
   }
 
-  /**
-   * \brief Mutator of SO2 group
-   */
-  EIGEN_STRONG_INLINE
-  SO2Reference so2() {
-    return static_cast<Derived*>(this)->so2();
+  /// Mutator of SO3 group.
+  ///
+  SOPHUS_FUNC
+  SO2Type& so2() { return static_cast<Derived*>(this)->so2(); }
+
+  /// Accessor of SO3 group.
+  ///
+  SOPHUS_FUNC
+  SO2Type const& so2() const {
+    return static_cast<Derived const*>(this)->so2();
   }
 
-  /**
-   * \brief Accessor of SO2 group
-   */
-  EIGEN_STRONG_INLINE
-  ConstSO2Reference so2() const {
-    return static_cast<const Derived*>(this)->so2();
-  }
-
-  /**
-   * \brief Mutator of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  TranslationReference translation() {
+  /// Mutator of translation vector.
+  ///
+  SOPHUS_FUNC
+  TranslationType& translation() {
     return static_cast<Derived*>(this)->translation();
   }
 
-  /**
-   * \brief Accessor of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  ConstTranslationReference translation() const {
-    return static_cast<const Derived*>(this)->translation();
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC
+  TranslationType const& translation() const {
+    return static_cast<Derived const*>(this)->translation();
   }
 
-  /**
-   * \brief Accessor of unit complex number
-   *
-   * No direct write access is given to ensure the complex number stays
-   * normalized.
-   */
-  inline
-  typename internal::traits<Derived>::SO2Type::ConstComplexReference
+  /// Accessor of unit complex number.
+  ///
+  SOPHUS_FUNC
+  typename Eigen::internal::traits<Derived>::SO2Type::ComplexT const&
   unit_complex() const {
     return so2().unit_complex();
   }
-
-  ////////////////////////////////////////////////////////////////////////////
-  // public static functions
-  ////////////////////////////////////////////////////////////////////////////
-
-  /**
-   * \param   b 3-vector representation of Lie algebra element
-   * \returns   derivative of Lie bracket
-   *
-   * This function returns \f$ \frac{\partial}{\partial a} [a, b]_{se2} \f$
-   * with \f$ [a, b]_{se2} \f$ being the lieBracket() of the Lie algebra se2.
-   *
-   * \see lieBracket()
-   */
-  inline static
-  const Transformation d_lieBracketab_by_d_a(const Tangent & b) {
-    static const Scalar zero = static_cast<Scalar>(0);
-    Matrix<Scalar,2,1> upsilon2 = b.template head<2>();
-    Scalar theta2 = b[2];
-
-    Transformation res;
-    res <<    zero, theta2, -upsilon2[1]
-        ,  -theta2,   zero,  upsilon2[0]
-        ,     zero,   zero,         zero;
-    return res;
-  }
-
-  /**
-   * \brief Group exponential
-   *
-   * \param a tangent space element (3-vector)
-   * \returns corresponding element of the group SE2
-   *
-   * The first two components of \f$ a \f$ represent the translational
-   * part \f$ \upsilon \f$ in the tangent space of SE2, while the last
-   * components of \f$ a \f$ is the rotation angle \f$ \theta \f$.
-   *
-   * To be more specific, this function computes \f$ \exp(\widehat{a}) \f$
-   * with \f$ \exp(\cdot) \f$ being the matrix exponential
-   * and \f$ \widehat{\cdot} \f$ the hat()-operator of SE2.
-   *
-   * \see hat()
-   * \see log()
-   */
-  inline static
-  const SE2Group<Scalar> exp(const Tangent & a) {
-    Scalar theta = a[2];
-    const SO2Group<Scalar> & so2 = SO2Group<Scalar>::exp(theta);
-    Scalar sin_theta_by_theta;
-    Scalar one_minus_cos_theta_by_theta;
-
-    if(std::abs(theta)<SophusConstants<Scalar>::epsilon()) {
-      Scalar theta_sq = theta*theta;
-      sin_theta_by_theta
-          = static_cast<Scalar>(1.) - static_cast<Scalar>(1./6.)*theta_sq;
-      one_minus_cos_theta_by_theta
-          = static_cast<Scalar>(0.5)*theta
-          - static_cast<Scalar>(1./24.)*theta*theta_sq;
-    } else {
-      sin_theta_by_theta = so2.unit_complex().y()/theta;
-      one_minus_cos_theta_by_theta
-          = (static_cast<Scalar>(1.) - so2.unit_complex().x())/theta;
-    }
-    Matrix<Scalar,2,1> trans
-        (sin_theta_by_theta*a[0] - one_minus_cos_theta_by_theta*a[1],
-        one_minus_cos_theta_by_theta * a[0]+sin_theta_by_theta*a[1]);
-    return SE2Group<Scalar>(so2, trans);
-  }
-
-  /**
-   * \brief Generators
-   *
-   * \pre \f$ i \in \{0,1,2\} \f$
-   * \returns \f$ i \f$th generator \f$ G_i \f$ of SE2
-   *
-   * The infinitesimal generators of SE2 are: \f[
-   *        G_0 = \left( \begin{array}{ccc}
-   *                          0&  0&  1\\
-   *                          0&  0&  0\\
-   *                          0&  0&  0\\
-   *                     \end{array} \right),
-   *        G_1 = \left( \begin{array}{cccc}
-   *                          0&  0&  0\\
-   *                          0&  0&  1\\
-   *                          0&  0&  0\\
-   *                     \end{array} \right),
-   *        G_2 = \left( \begin{array}{cccc}
-   *                          0&  0&  0&\\
-   *                          0&  0& -1&\\
-   *                          0&  1&  0&\\
-   *                     \end{array} \right),
-   * \f]
-   * \see hat()
-   */
-  inline static
-  const Transformation generator(int i) {
-    if (i<0 || i>2) {
-      throw SophusException("i is not in range [0,2].");
-    }
-    Tangent e;
-    e.setZero();
-    e[i] = static_cast<Scalar>(1);
-    return hat(e);
-  }
-
-  /**
-   * \brief hat-operator
-   *
-   * \param omega 3-vector representation of Lie algebra element
-   * \returns     3x3-matrix representatin of Lie algebra element
-   *
-   * Formally, the hat-operator of SE2 is defined
-   * as \f$ \widehat{\cdot}: \mathbf{R}^3 \rightarrow \mathbf{R}^{2\times 2},
-   * \quad \widehat{\omega} = \sum_{i=0}^2 G_i \omega_i \f$
-   * with \f$ G_i \f$ being the ith infinitesial generator().
-   *
-   * \see generator()
-   * \see vee()
-   */
-  inline static
-  const Transformation hat(const Tangent & v) {
-    Transformation Omega;
-    Omega.setZero();
-    Omega.template topLeftCorner<2,2>() = SO2Group<Scalar>::hat(v[2]);
-    Omega.col(2).template head<2>() = v.template head<2>();
-    return Omega;
-  }
-
-  /**
-   * \brief Lie bracket
-   *
-   * \param a 3-vector representation of Lie algebra element
-   * \param b 3-vector representation of Lie algebra element
-   * \returns 3-vector representation of Lie algebra element
-   *
-   * It computes the bracket of SE2. To be more specific, it
-   * computes \f$ [a, b]_{se2}
-   * := [\widehat{a_1}, \widehat{b_2}]^\vee \f$
-   * with \f$ [A,B] = AB-BA \f$ being the matrix
-   * commutator, \f$ \widehat{\cdot} \f$ the
-   * hat()-operator and \f$ (\cdot)^\vee \f$ the vee()-operator of SE2.
-   *
-   * \see hat()
-   * \see vee()
-   */
-  inline static
-  const Tangent lieBracket(const Tangent & a,
-                           const Tangent & b) {
-    Matrix<Scalar,2,1> upsilon1 = a.template head<2>();
-    Matrix<Scalar,2,1> upsilon2 = b.template head<2>();
-    Scalar theta1 = a[2];
-    Scalar theta2 = b[2];
-
-    return Tangent(-theta1*upsilon2[1] + theta2*upsilon1[1],
-        theta1*upsilon2[0] - theta2*upsilon1[0],
-        static_cast<Scalar>(0));
-  }
-
-  /**
-   * \brief Logarithmic map
-   *
-   * \param other element of the group SE2
-   * \returns     corresponding tangent space element
-   *              (translational part \f$ \upsilon \f$
-   *               and rotation vector \f$ \omega \f$)
-   *
-   * Computes the logarithmic, the inverse of the group exponential.
-   * To be specific, this function computes \f$ \log({\cdot})^\vee \f$
-   * with \f$ \vee(\cdot) \f$ being the matrix logarithm
-   * and \f$ \vee{\cdot} \f$ the vee()-operator of SE2.
-   *
-   * \see exp()
-   * \see vee()
-   */
-  inline static
-  const Tangent log(const SE2Group<Scalar> & other) {
-    Tangent upsilon_theta;
-    const SO2Group<Scalar> & so2 = other.so2();
-    Scalar theta = SO2Group<Scalar>::log(so2);
-    upsilon_theta[2] = theta;
-    Scalar halftheta = static_cast<Scalar>(0.5)*theta;
-    Scalar halftheta_by_tan_of_halftheta;
-
-    const Matrix<Scalar,2,1> & z = so2.unit_complex();
-    Scalar real_minus_one = z.x()-static_cast<Scalar>(1.);
-    if (std::abs(real_minus_one)<SophusConstants<Scalar>::epsilon()) {
-      halftheta_by_tan_of_halftheta
-          = static_cast<Scalar>(1.)
-          - static_cast<Scalar>(1./12)*theta*theta;
-    } else {
-      halftheta_by_tan_of_halftheta
-          = -(halftheta*z.y())/(real_minus_one);
-    }
-    Matrix<Scalar,2,2> V_inv;
-    V_inv <<  halftheta_by_tan_of_halftheta,                      halftheta
-        ,                        -halftheta,  halftheta_by_tan_of_halftheta;
-    upsilon_theta.template head<2>() = V_inv*other.translation();
-    return upsilon_theta;
-  }
-
-  /**
-   * \brief vee-operator
-   *
-   * \param Omega 3x3-matrix representation of Lie algebra element
-   * \returns     3-vector representatin of Lie algebra element
-   *
-   * This is the inverse of the hat()-operator.
-   *
-   * \see hat()
-   */
-  inline static
-  const Tangent vee(const Transformation & Omega) {
-    Tangent upsilon_omega;
-    upsilon_omega.template head<2>() = Omega.col(2).template head<2>();
-    upsilon_omega[2]
-        = SO2Group<Scalar>::vee(Omega.template topLeftCorner<2,2>());
-    return upsilon_omega;
-  }
 };
 
-/**
- * \brief SE2 default type - Constructors and default storage for SE2 Type
- */
-template<typename _Scalar, int _Options>
-class SE2Group : public SE2GroupBase<SE2Group<_Scalar,_Options> > {
-  typedef SE2GroupBase<SE2Group<_Scalar,_Options> > Base;
+/// SE2 using default storage; derived from SE2Base.
+template <class Scalar_, int Options>
+class SE2 : public SE2Base<SE2<Scalar_, Options>> {
+ public:
+  using Base = SE2Base<SE2<Scalar_, Options>>;
+  static int constexpr DoF = Base::DoF;
+  static int constexpr num_parameters = Base::num_parameters;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<SE2Group<_Scalar,_Options> >
-  ::Scalar Scalar;
-  /** \brief translation reference type */
-  typedef typename internal::traits<SE2Group<_Scalar,_Options> >
-  ::TranslationType & TranslationReference;
-  typedef const typename internal::traits<SE2Group<_Scalar,_Options> >
-  ::TranslationType & ConstTranslationReference;
-  /** \brief SO2 reference type */
-  typedef typename internal::traits<SE2Group<_Scalar,_Options> >
-  ::SO2Type & SO2Reference;
-  /** \brief SO2 const reference type */
-  typedef const typename internal::traits<SE2Group<_Scalar,_Options> >
-  ::SO2Type & ConstSO2Reference;
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+  using SO2Member = SO2<Scalar, Options>;
+  using TranslationMember = Vector2<Scalar, Options>;
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  /**
-   * \brief Default constructor
-   *
-   * Initialize Complex to identity rotation and translation to zero.
-   */
-  inline
-  SE2Group()
-    : translation_( Matrix<Scalar,2,1>::Zero() )
-  {
+  /// Default constructor initializes rigid body motion to the identity.
+  ///
+  SOPHUS_FUNC SE2();
+
+  /// Copy constructor
+  ///
+  SOPHUS_FUNC SE2(SE2 const& other) = default;
+
+  /// Copy-like constructor from OtherDerived
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC SE2(SE2Base<OtherDerived> const& other)
+      : so2_(other.so2()), translation_(other.translation()) {
+    static_assert(std::is_same<typename OtherDerived::Scalar, Scalar>::value,
+                  "must be same Scalar type");
   }
 
-  /**
-   * \brief Copy constructor
-   */
-  template<typename OtherDerived> inline
-  SE2Group(const SE2GroupBase<OtherDerived> & other)
-    : so2_(other.so2()), translation_(other.translation()) {
+  /// Constructor from SO3 and translation vector
+  ///
+  template <class OtherDerived, class D>
+  SOPHUS_FUNC SE2(SO2Base<OtherDerived> const& so2,
+                  Eigen::MatrixBase<D> const& translation)
+      : so2_(so2), translation_(translation) {
+    static_assert(std::is_same<typename OtherDerived::Scalar, Scalar>::value,
+                  "must be same Scalar type");
+    static_assert(std::is_same<typename D::Scalar, Scalar>::value,
+                  "must be same Scalar type");
   }
 
-  /**
-   * \brief Constructor from SO2 and translation vector
-   */
-  template<typename OtherDerived> inline
-  SE2Group(const SO2GroupBase<OtherDerived> & so2,
-           const Point & translation)
-    : so2_(so2), translation_(translation) {
-  }
+  /// Constructor from rotation matrix and translation vector
+  ///
+  /// Precondition: Rotation matrix needs to be orthogonal with determinant
+  /// of 1.
+  ///
+  SOPHUS_FUNC
+  SE2(typename SO2<Scalar>::Transformation const& rotation_matrix,
+      Point const& translation)
+      : so2_(rotation_matrix), translation_(translation) {}
 
-  /**
-   * \brief Constructor from rotation matrix and translation vector
-   *
-   * \pre rotation matrix need to be orthogonal with determinant of 1
-   */
-  inline
-  SE2Group(const typename SO2Group<Scalar>::Transformation & rotation_matrix,
-           const Point & translation)
-    : so2_(rotation_matrix), translation_(translation) {
-  }
+  /// Constructor from rotation angle and translation vector.
+  ///
+  SOPHUS_FUNC SE2(Scalar const& theta, Point const& translation)
+      : so2_(theta), translation_(translation) {}
 
-  /**
-   * \brief Constructor from rotation angle and translation vector
-   */
-  inline
-  SE2Group(const Scalar & theta,
-           const Point & translation)
-    : so2_(theta), translation_(translation) {
-  }
+  /// Constructor from complex number and translation vector
+  ///
+  /// Precondition: ``complex`` must not be close to zero.
+  SOPHUS_FUNC SE2(Vector2<Scalar> const& complex, Point const& translation)
+      : so2_(complex), translation_(translation) {}
 
-  /**
-   * \brief Constructor from complex number and translation vector
-   *
-   * \pre complex must not be zero
-   */
-  inline
-  SE2Group(const std::complex<Scalar> & complex,
-           const Point & translation)
-    : so2_(complex), translation_(translation) {
-  }
+  /// Constructor from 3x3 matrix
+  ///
+  /// Precondition: Rotation matrix needs to be orthogonal with determinant
+  /// of 1. The last row must be ``(0, 0, 1)``.
+  ///
+  SOPHUS_FUNC explicit SE2(Transformation const& T)
+      : so2_(T.template topLeftCorner<2, 2>().eval()),
+        translation_(T.template block<2, 1>(0, 2)) {}
 
-  /**
-   * \brief Constructor from 3x3 matrix
-   *
-   * \pre 2x2 sub-matrix need to be orthogonal with determinant of 1
-   */
-  inline explicit
-  SE2Group(const Transformation & T)
-    : so2_(T.template topLeftCorner<2,2>()),
-      translation_(T.template block<2,1>(0,2)) {
-  }
-
-  /**
-   * \returns pointer to internal data
-   *
-   * This provides unsafe read/write access to internal data. SE2 is represented
-   * by a pair of an SO2 element (two parameters) and a translation vector (two
-   * parameters). The user needs to take care of that the complex
-   * stays normalized.
-   *
-   * /see normalize()
-   */
-  EIGEN_STRONG_INLINE
-  Scalar* data() {
+  /// This provides unsafe read/write access to internal data. SO(2) is
+  /// represented by a complex number (two parameters). When using direct write
+  /// access, the user needs to take care of that the complex number stays
+  /// normalized.
+  ///
+  SOPHUS_FUNC Scalar* data() {
     // so2_ and translation_ are layed out sequentially with no padding
     return so2_.data();
   }
 
-  /**
-   * \returns const pointer to internal data
-   *
-   * Const version of data().
-   */
-  EIGEN_STRONG_INLINE
-  const Scalar* data() const {
-    // so2_ and translation_ are layed out sequentially with no padding
+  /// Const version of data() above.
+  ///
+  SOPHUS_FUNC Scalar const* data() const {
+    /// so2_ and translation_ are layed out sequentially with no padding
     return so2_.data();
   }
 
-  /**
-   * \brief Accessor of SO2
-   */
-  EIGEN_STRONG_INLINE
-  SO2Reference so2() {
-    return so2_;
-  }
+  /// Accessor of SO3
+  ///
+  SOPHUS_FUNC SO2Member& so2() { return so2_; }
 
-  /**
-   * \brief Mutator of SO2
-   */
-  EIGEN_STRONG_INLINE
-  ConstSO2Reference so2() const {
-    return so2_;
-  }
+  /// Mutator of SO3
+  ///
+  SOPHUS_FUNC SO2Member const& so2() const { return so2_; }
 
-  /**
-   * \brief Mutator of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  TranslationReference translation() {
+  /// Mutator of translation vector
+  ///
+  SOPHUS_FUNC TranslationMember& translation() { return translation_; }
+
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC TranslationMember const& translation() const {
     return translation_;
   }
 
-  /**
-   * \brief Accessor of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  ConstTranslationReference translation() const {
-    return translation_;
+  /// Returns derivative of exp(x) wrt. x.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
+      Tangent const& upsilon_theta) {
+    using std::abs;
+    using std::cos;
+    using std::pow;
+    using std::sin;
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    Sophus::Vector<Scalar, 2> upsilon = upsilon_theta.template head<2>();
+    Scalar theta = upsilon_theta[2];
+
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      Scalar const o(0);
+      Scalar const i(1);
+
+      // clang-format off
+      J << o, o, o, o, o, i, i, o, -Scalar(0.5) * upsilon[1], o, i,
+          Scalar(0.5) * upsilon[0];
+      // clang-format on
+      return J;
+    }
+
+    Scalar const c0 = sin(theta);
+    Scalar const c1 = cos(theta);
+    Scalar const c2 = 1.0 / theta;
+    Scalar const c3 = c0 * c2;
+    Scalar const c4 = -c1 + Scalar(1);
+    Scalar const c5 = c2 * c4;
+    Scalar const c6 = c1 * c2;
+    Scalar const c7 = pow(theta, -2);
+    Scalar const c8 = c0 * c7;
+    Scalar const c9 = c4 * c7;
+
+    Scalar const o = Scalar(0);
+    J(0, 0) = o;
+    J(0, 1) = o;
+    J(0, 2) = -c0;
+    J(1, 0) = o;
+    J(1, 1) = o;
+    J(1, 2) = c1;
+    J(2, 0) = c3;
+    J(2, 1) = -c5;
+    J(2, 2) =
+        -c3 * upsilon[1] + c6 * upsilon[0] - c8 * upsilon[0] + c9 * upsilon[1];
+    J(3, 0) = c5;
+    J(3, 1) = c3;
+    J(3, 2) =
+        c3 * upsilon[0] + c6 * upsilon[1] - c8 * upsilon[1] - c9 * upsilon[0];
+    return J;
   }
 
-protected:
-  Sophus::SO2Group<Scalar> so2_;
-  Matrix<Scalar,2,1> translation_;
+  /// Returns derivative of exp(x) wrt. x_i at x=0.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF>
+  Dx_exp_x_at_0() {
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    Scalar const o(0);
+    Scalar const i(1);
+
+    // clang-format off
+    J << o, o, o, o, o, i, i, o, o, o, i, o;
+    // clang-format on
+    return J;
+  }
+
+  /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.
+  ///
+  SOPHUS_FUNC static Transformation Dxi_exp_x_matrix_at_0(int i) {
+    return generator(i);
+  }
+
+  /// Group exponential
+  ///
+  /// This functions takes in an element of tangent space (= twist ``a``) and
+  /// returns the corresponding element of the group SE(2).
+  ///
+  /// The first two components of ``a`` represent the translational part
+  /// ``upsilon`` in the tangent space of SE(2), while the last three components
+  /// of ``a`` represents the rotation vector ``omega``.
+  /// To be more specific, this function computes ``expmat(hat(a))`` with
+  /// ``expmat(.)`` being the matrix exponential and ``hat(.)`` the hat-operator
+  /// of SE(2), see below.
+  ///
+  SOPHUS_FUNC static SE2<Scalar> exp(Tangent const& a) {
+    Scalar theta = a[2];
+    SO2<Scalar> so2 = SO2<Scalar>::exp(theta);
+    Scalar sin_theta_by_theta;
+    Scalar one_minus_cos_theta_by_theta;
+    using std::abs;
+
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      Scalar theta_sq = theta * theta;
+      sin_theta_by_theta = Scalar(1.) - Scalar(1. / 6.) * theta_sq;
+      one_minus_cos_theta_by_theta =
+          Scalar(0.5) * theta - Scalar(1. / 24.) * theta * theta_sq;
+    } else {
+      sin_theta_by_theta = so2.unit_complex().y() / theta;
+      one_minus_cos_theta_by_theta =
+          (Scalar(1.) - so2.unit_complex().x()) / theta;
+    }
+    Vector2<Scalar> trans(
+        sin_theta_by_theta * a[0] - one_minus_cos_theta_by_theta * a[1],
+        one_minus_cos_theta_by_theta * a[0] + sin_theta_by_theta * a[1]);
+    return SE2<Scalar>(so2, trans);
+  }
+
+  /// Returns closest SE3 given arbitrary 4x4 matrix.
+  ///
+  template <class S = Scalar>
+  static SOPHUS_FUNC enable_if_t<std::is_floating_point<S>::value, SE2>
+  fitToSE2(Matrix3<Scalar> const& T) {
+    return SE2(SO2<Scalar>::fitToSO2(T.template block<2, 2>(0, 0)),
+               T.template block<2, 1>(0, 2));
+  }
+
+  /// Returns the ith infinitesimal generators of SE(2).
+  ///
+  /// The infinitesimal generators of SE(2) are:
+  ///
+  /// ```
+  ///         |  0  0  1 |
+  ///   G_0 = |  0  0  0 |
+  ///         |  0  0  0 |
+  ///
+  ///         |  0  0  0 |
+  ///   G_1 = |  0  0  1 |
+  ///         |  0  0  0 |
+  ///
+  ///         |  0 -1  0 |
+  ///   G_2 = |  1  0  0 |
+  ///         |  0  0  0 |
+  /// ```
+  ///
+  /// Precondition: ``i`` must be in 0, 1 or 2.
+  ///
+  SOPHUS_FUNC static Transformation generator(int i) {
+    SOPHUS_ENSURE(i >= 0 || i <= 2, "i should be in range [0,2].");
+    Tangent e;
+    e.setZero();
+    e[i] = Scalar(1);
+    return hat(e);
+  }
+
+  /// hat-operator
+  ///
+  /// It takes in the 3-vector representation (= twist) and returns the
+  /// corresponding matrix representation of Lie algebra element.
+  ///
+  /// Formally, the hat()-operator of SE(3) is defined as
+  ///
+  ///   ``hat(.): R^3 -> R^{3x33},  hat(a) = sum_i a_i * G_i``  (for i=0,1,2)
+  ///
+  /// with ``G_i`` being the ith infinitesimal generator of SE(2).
+  ///
+  /// The corresponding inverse is the vee()-operator, see below.
+  ///
+  SOPHUS_FUNC static Transformation hat(Tangent const& a) {
+    Transformation Omega;
+    Omega.setZero();
+    Omega.template topLeftCorner<2, 2>() = SO2<Scalar>::hat(a[2]);
+    Omega.col(2).template head<2>() = a.template head<2>();
+    return Omega;
+  }
+
+  /// Lie bracket
+  ///
+  /// It computes the Lie bracket of SE(2). To be more specific, it computes
+  ///
+  ///   ``[omega_1, omega_2]_se2 := vee([hat(omega_1), hat(omega_2)])``
+  ///
+  /// with ``[A,B] := AB-BA`` being the matrix commutator, ``hat(.)`` the
+  /// hat()-operator and ``vee(.)`` the vee()-operator of SE(2).
+  ///
+  SOPHUS_FUNC static Tangent lieBracket(Tangent const& a, Tangent const& b) {
+    Vector2<Scalar> upsilon1 = a.template head<2>();
+    Vector2<Scalar> upsilon2 = b.template head<2>();
+    Scalar theta1 = a[2];
+    Scalar theta2 = b[2];
+
+    return Tangent(-theta1 * upsilon2[1] + theta2 * upsilon1[1],
+                   theta1 * upsilon2[0] - theta2 * upsilon1[0], Scalar(0));
+  }
+
+  /// Construct pure rotation.
+  ///
+  static SOPHUS_FUNC SE2 rot(Scalar const& x) {
+    return SE2(SO2<Scalar>(x), Sophus::Vector2<Scalar>::Zero());
+  }
+
+  /// Draw uniform sample from SE(2) manifold.
+  ///
+  /// Translations are drawn component-wise from the range [-1, 1].
+  ///
+  template <class UniformRandomBitGenerator>
+  static SE2 sampleUniform(UniformRandomBitGenerator& generator) {
+    std::uniform_real_distribution<Scalar> uniform(Scalar(-1), Scalar(1));
+    return SE2(SO2<Scalar>::sampleUniform(generator),
+               Vector2<Scalar>(uniform(generator), uniform(generator)));
+  }
+
+  /// Construct a translation only SE(2) instance.
+  ///
+  template <class T0, class T1>
+  static SOPHUS_FUNC SE2 trans(T0 const& x, T1 const& y) {
+    return SE2(SO2<Scalar>(), Vector2<Scalar>(x, y));
+  }
+
+  static SOPHUS_FUNC SE2 trans(Vector2<Scalar> const& xy) {
+    return SE2(SO2<Scalar>(), xy);
+  }
+
+  /// Construct x-axis translation.
+  ///
+  static SOPHUS_FUNC SE2 transX(Scalar const& x) {
+    return SE2::trans(x, Scalar(0));
+  }
+
+  /// Construct y-axis translation.
+  ///
+  static SOPHUS_FUNC SE2 transY(Scalar const& y) {
+    return SE2::trans(Scalar(0), y);
+  }
+
+  /// vee-operator
+  ///
+  /// It takes the 3x3-matrix representation ``Omega`` and maps it to the
+  /// corresponding 3-vector representation of Lie algebra.
+  ///
+  /// This is the inverse of the hat()-operator, see above.
+  ///
+  /// Precondition: ``Omega`` must have the following structure:
+  ///
+  ///                |  0 -d  a |
+  ///                |  d  0  b |
+  ///                |  0  0  0 |
+  ///
+  SOPHUS_FUNC static Tangent vee(Transformation const& Omega) {
+    SOPHUS_ENSURE(
+        Omega.row(2).template lpNorm<1>() < Constants<Scalar>::epsilon(),
+        "Omega: \n%", Omega);
+    Tangent upsilon_omega;
+    upsilon_omega.template head<2>() = Omega.col(2).template head<2>();
+    upsilon_omega[2] = SO2<Scalar>::vee(Omega.template topLeftCorner<2, 2>());
+    return upsilon_omega;
+  }
+
+ protected:
+  SO2Member so2_;
+  TranslationMember translation_;
 };
 
+template <class Scalar, int Options>
+SE2<Scalar, Options>::SE2() : translation_(TranslationMember::Zero()) {
+  static_assert(std::is_standard_layout<SE2>::value,
+                "Assume standard layout for the use of offsetof check below.");
+  static_assert(
+      offsetof(SE2, so2_) + sizeof(Scalar) * SO2<Scalar>::num_parameters ==
+          offsetof(SE2, translation_),
+      "This class assumes packed storage and hence will only work "
+      "correctly depending on the compiler (options) - in "
+      "particular when using [this->data(), this-data() + "
+      "num_parameters] to access the raw data in a contiguous fashion.");
+}
 
-} // end namespace
-
+}  // namespace Sophus
 
 namespace Eigen {
-/**
- * \brief Specialisation of Eigen::Map for SE2GroupBase
- *
- * Allows us to wrap SE2 Objects around POD array
- * (e.g. external c style complex)
- */
-template<typename _Scalar, int _Options>
-class Map<Sophus::SE2Group<_Scalar>, _Options>
-    : public Sophus::SE2GroupBase<Map<Sophus::SE2Group<_Scalar>, _Options> >
-{
-  typedef Sophus::SE2GroupBase<Map<Sophus::SE2Group<_Scalar>, _Options> > Base;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief translation reference type */
-  typedef typename internal::traits<Map>::TranslationType &
-  TranslationReference;
-  /** \brief translation reference type */
-  typedef const typename internal::traits<Map>::TranslationType &
-  ConstTranslationReference;
-  /** \brief SO2 reference type */
-  typedef typename internal::traits<Map>::SO2Type & SO2Reference;
-  /** \brief SO2 const reference type */
-  typedef const typename internal::traits<Map>::SO2Type & ConstSO2Reference;
+/// Specialization of Eigen::Map for ``SE2``; derived from SE2Base.
+///
+/// Allows us to wrap SE2 objects around POD array.
+template <class Scalar_, int Options>
+class Map<Sophus::SE2<Scalar_>, Options>
+    : public Sophus::SE2Base<Map<Sophus::SE2<Scalar_>, Options>> {
+ public:
+  using Base = Sophus::SE2Base<Map<Sophus::SE2<Scalar_>, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
+  // LCOV_EXCL_START
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  // LCOV_EXCL_STOP
 
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
+  SOPHUS_FUNC
   Map(Scalar* coeffs)
-    : so2_(coeffs),
-      translation_(coeffs+Sophus::SO2Group<Scalar>::num_parameters) {
-  }
+      : so2_(coeffs),
+        translation_(coeffs + Sophus::SO2<Scalar>::num_parameters) {}
 
-  /**
-   * \brief Mutator of SO2
-   */
-  EIGEN_STRONG_INLINE
-  SO2Reference so2() {
+  /// Mutator of SO3
+  ///
+  SOPHUS_FUNC Map<Sophus::SO2<Scalar>, Options>& so2() { return so2_; }
+
+  /// Accessor of SO3
+  ///
+  SOPHUS_FUNC Map<Sophus::SO2<Scalar>, Options> const& so2() const {
     return so2_;
   }
 
-  /**
-   * \brief Accessor of SO2
-   */
-  EIGEN_STRONG_INLINE
-  ConstSO2Reference so2() const {
-    return so2_;
-  }
-
-  /**
-   * \brief Mutator of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  TranslationReference translation() {
+  /// Mutator of translation vector
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector2<Scalar>, Options>& translation() {
     return translation_;
   }
 
-  /**
-   * \brief Accessor of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  ConstTranslationReference translation() const {
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector2<Scalar>, Options> const& translation() const {
     return translation_;
   }
 
-protected:
-  Map<Sophus::SO2Group<Scalar>,_Options> so2_;
-  Map<Matrix<Scalar,2,1>,_Options> translation_;
+ protected:
+  Map<Sophus::SO2<Scalar>, Options> so2_;
+  Map<Sophus::Vector2<Scalar>, Options> translation_;
 };
 
-/**
- * \brief Specialisation of Eigen::Map for const SE2GroupBase
- *
- * Allows us to wrap SE2 Objects around POD array
- * (e.g. external c style complex)
- */
-template<typename _Scalar, int _Options>
-class Map<const Sophus::SE2Group<_Scalar>, _Options>
-    : public Sophus::SE2GroupBase<
-    Map<const Sophus::SE2Group<_Scalar>, _Options> > {
-  typedef Sophus::SE2GroupBase<Map<const Sophus::SE2Group<_Scalar>, _Options> >
-  Base;
+/// Specialization of Eigen::Map for ``SE2 const``; derived from SE2Base.
+///
+/// Allows us to wrap SE2 objects around POD array.
+template <class Scalar_, int Options>
+class Map<Sophus::SE2<Scalar_> const, Options>
+    : public Sophus::SE2Base<Map<Sophus::SE2<Scalar_> const, Options>> {
+ public:
+  using Base = Sophus::SE2Base<Map<Sophus::SE2<Scalar_> const, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief translation reference type */
-  typedef const typename internal::traits<Map>::TranslationType &
-  ConstTranslationReference;
-  /** \brief SO2 const reference type */
-  typedef const typename internal::traits<Map>::SO2Type & ConstSO2Reference;
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(const Scalar* coeffs)
-    : so2_(coeffs),
-      translation_(coeffs+Sophus::SO2Group<Scalar>::num_parameters) {
-  }
+  SOPHUS_FUNC Map(Scalar const* coeffs)
+      : so2_(coeffs),
+        translation_(coeffs + Sophus::SO2<Scalar>::num_parameters) {}
 
-  EIGEN_STRONG_INLINE
-  Map(const Scalar* trans_coeffs, const Scalar* rot_coeffs)
-    : translation_(trans_coeffs), so2_(rot_coeffs){
-  }
-
-  /**
-   * \brief Accessor of SO2
-   */
-  EIGEN_STRONG_INLINE
-  ConstSO2Reference so2() const {
+  /// Accessor of SO3
+  ///
+  SOPHUS_FUNC Map<Sophus::SO2<Scalar> const, Options> const& so2() const {
     return so2_;
   }
 
-  /**
-   * \brief Accessor of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  ConstTranslationReference translation() const {
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector2<Scalar> const, Options> const& translation()
+      const {
     return translation_;
   }
 
-protected:
-  const Map<const Sophus::SO2Group<Scalar>,_Options> so2_;
-  const Map<const Matrix<Scalar,2,1>,_Options> translation_;
+ protected:
+  Map<Sophus::SO2<Scalar> const, Options> const so2_;
+  Map<Sophus::Vector2<Scalar> const, Options> const translation_;
 };
-
-}
+}  // namespace Eigen
 
 #endif

--- a/thirdparty/sophus/se3.hpp
+++ b/thirdparty/sophus/se3.hpp
@@ -1,537 +1,879 @@
-// This file is part of Sophus.
-//
-// Copyright 2011-2013 Hauke Strasdat
-//           2012-2013 Steven Lovegrove
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal in the Software without restriction, including without limitation the
-// rights  to use, copy, modify, merge, publish, distribute, sublicense, and/or
-// sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
+/// @file
+/// Special Euclidean group SE(3) - rotation and translation in 3d.
 
 #ifndef SOPHUS_SE3_HPP
 #define SOPHUS_SE3_HPP
 
 #include "so3.hpp"
 
-////////////////////////////////////////////////////////////////////////////
-// Forward Declarations / typedefs
-////////////////////////////////////////////////////////////////////////////
-
 namespace Sophus {
-template<typename _Scalar, int _Options=0> class SE3Group;
-typedef SE3Group<double> SE3 EIGEN_DEPRECATED;
-typedef SE3Group<double> SE3d; /**< double precision SE3 */
-typedef SE3Group<float> SE3f;  /**< single precision SE3 */
-typedef Matrix<double,6,1> Vector6d;
-typedef Matrix<double,6,6> Matrix6d;
-typedef Matrix<float,6,1> Vector6f;
-typedef Matrix<float,6,6> Matrix6f;
-}
-
-////////////////////////////////////////////////////////////////////////////
-// Eigen Traits (For querying derived types in CRTP hierarchy)
-////////////////////////////////////////////////////////////////////////////
+template <class Scalar_, int Options = 0>
+class SE3;
+using SE3d = SE3<double>;
+using SE3f = SE3<float>;
+}  // namespace Sophus
 
 namespace Eigen {
 namespace internal {
 
-template<typename _Scalar, int _Options>
-struct traits<Sophus::SE3Group<_Scalar,_Options> > {
-  typedef _Scalar Scalar;
-  typedef Matrix<Scalar,3,1> TranslationType;
-  typedef Sophus::SO3Group<Scalar> SO3Type;
+template <class Scalar_, int Options>
+struct traits<Sophus::SE3<Scalar_, Options>> {
+  using Scalar = Scalar_;
+  using TranslationType = Sophus::Vector3<Scalar, Options>;
+  using SO3Type = Sophus::SO3<Scalar, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<Sophus::SE3Group<_Scalar>, _Options> >
-    : traits<Sophus::SE3Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<Matrix<Scalar,3,1>,_Options> TranslationType;
-  typedef Map<Sophus::SO3Group<Scalar>,_Options> SO3Type;
+template <class Scalar_, int Options>
+struct traits<Map<Sophus::SE3<Scalar_>, Options>>
+    : traits<Sophus::SE3<Scalar_, Options>> {
+  using Scalar = Scalar_;
+  using TranslationType = Map<Sophus::Vector3<Scalar>, Options>;
+  using SO3Type = Map<Sophus::SO3<Scalar>, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<const Sophus::SE3Group<_Scalar>, _Options> >
-    : traits<const Sophus::SE3Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<const Matrix<Scalar,3,1>,_Options> TranslationType;
-  typedef Map<const Sophus::SO3Group<Scalar>,_Options> SO3Type;
+template <class Scalar_, int Options>
+struct traits<Map<Sophus::SE3<Scalar_> const, Options>>
+    : traits<Sophus::SE3<Scalar_, Options> const> {
+  using Scalar = Scalar_;
+  using TranslationType = Map<Sophus::Vector3<Scalar> const, Options>;
+  using SO3Type = Map<Sophus::SO3<Scalar> const, Options>;
 };
-
-}
-}
+}  // namespace internal
+}  // namespace Eigen
 
 namespace Sophus {
-using namespace Eigen;
-using namespace std;
 
-/**
- * \brief SE3 base type - implements SE3 class but is storage agnostic
- *
- * [add more detailed description/tutorial]
- */
-template<typename Derived>
-class SE3GroupBase {
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
-  /** \brief translation reference type */
-  typedef typename internal::traits<Derived>::TranslationType &
-  TranslationReference;
-  /** \brief translation const reference type */
-  typedef const typename internal::traits<Derived>::TranslationType &
-  ConstTranslationReference;
-  /** \brief SO3 reference type */
-  typedef typename internal::traits<Derived>::SO3Type &
-  SO3Reference;
-  /** \brief SO3 const reference type */
-  typedef const typename internal::traits<Derived>::SO3Type &
-  ConstSO3Reference;
+/// SE3 base type - implements SE3 class but is storage agnostic.
+///
+/// SE(3) is the group of rotations  and translation in 3d. It is the
+/// semi-direct product of SO(3) and the 3d Euclidean vector space.  The class
+/// is represented using a composition of SO3  for rotation and a one 3-vector
+/// for translation.
+///
+/// SE(3) is neither compact, nor a commutative group.
+///
+/// See SO3 for more details of the rotation representation in 3d.
+///
+template <class Derived>
+class SE3Base {
+ public:
+  using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
+  using TranslationType =
+      typename Eigen::internal::traits<Derived>::TranslationType;
+  using SO3Type = typename Eigen::internal::traits<Derived>::SO3Type;
+  using QuaternionType = typename SO3Type::QuaternionType;
+  /// Degrees of freedom of manifold, number of dimensions in tangent space
+  /// (three for translation, three for rotation).
+  static int constexpr DoF = 6;
+  /// Number of internal parameters used (4-tuple for quaternion, three for
+  /// translation).
+  static int constexpr num_parameters = 7;
+  /// Group transformations are 4x4 matrices.
+  static int constexpr N = 4;
+  using Transformation = Matrix<Scalar, N, N>;
+  using Point = Vector3<Scalar>;
+  using HomogeneousPoint = Vector4<Scalar>;
+  using Line = ParametrizedLine3<Scalar>;
+  using Tangent = Vector<Scalar, DoF>;
+  using Adjoint = Matrix<Scalar, DoF, DoF>;
 
-  /** \brief degree of freedom of group
-    *        (three for translation, three for rotation) */
-  static const int DoF = 6;
-  /** \brief number of internal parameters used
-   *         (unit quaternion for rotation + translation 3-vector) */
-  static const int num_parameters = 7;
-  /** \brief group transformations are NxN matrices */
-  static const int N = 4;
-  /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
-  /** \brief point type */
-  typedef Matrix<Scalar,3,1> Point;
-  /** \brief tangent vector type */
-  typedef Matrix<Scalar,DoF,1> Tangent;
-  /** \brief adjoint transformation type */
-  typedef Matrix<Scalar,DoF,DoF> Adjoint;
+  /// For binary operations the return type is determined with the
+  /// ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  /// types, as well as other compatible scalar types such as Ceres::Jet and
+  /// double scalars with SE3 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
 
+  template <typename OtherDerived>
+  using SE3Product = SE3<ReturnScalar<OtherDerived>>;
 
-  /**
-   * \brief Adjoint transformation
-   *
-   * This function return the adjoint transformation \f$ Ad \f$ of the
-   * group instance \f$ A \f$  such that for all \f$ x \f$
-   * it holds that \f$ \widehat{Ad_A\cdot x} = A\widehat{x}A^{-1} \f$
-   * with \f$\ \widehat{\cdot} \f$ being the hat()-operator.
-   */
-  inline
-  const Adjoint Adj() const {
-    const Matrix<Scalar,3,3> & R = so3().matrix();
+  template <typename PointDerived>
+  using PointProduct = Vector3<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector4<ReturnScalar<HPointDerived>>;
+
+  /// Adjoint transformation
+  ///
+  /// This function return the adjoint transformation ``Ad`` of the group
+  /// element ``A`` such that for all ``x`` it holds that
+  /// ``hat(Ad_A * x) = A * hat(x) A^{-1}``. See hat-operator below.
+  ///
+  SOPHUS_FUNC Adjoint Adj() const {
+    Sophus::Matrix3<Scalar> const R = so3().matrix();
     Adjoint res;
-    res.block(0,0,3,3) = R;
-    res.block(3,3,3,3) = R;
-    res.block(0,3,3,3) = SO3Group<Scalar>::hat(translation())*R;
-    res.block(3,0,3,3) = Matrix<Scalar,3,3>::Zero(3,3);
+    res.block(0, 0, 3, 3) = R;
+    res.block(3, 3, 3, 3) = R;
+    res.block(0, 3, 3, 3) = SO3<Scalar>::hat(translation()) * R;
+    res.block(3, 0, 3, 3) = Matrix3<Scalar>::Zero(3, 3);
     return res;
   }
 
-  /**
-   * \returns copy of instance casted to NewScalarType
-   */
-  template<typename NewScalarType>
-  inline SE3Group<NewScalarType> cast() const {
-    return
-        SE3Group<NewScalarType>(so3().template cast<NewScalarType>(),
-                                translation().template cast<NewScalarType>() );
+  /// Extract rotation angle about canonical X-axis
+  ///
+  Scalar angleX() const { return so3().angleX(); }
+
+  /// Extract rotation angle about canonical Y-axis
+  ///
+  Scalar angleY() const { return so3().angleY(); }
+
+  /// Extract rotation angle about canonical Z-axis
+  ///
+  Scalar angleZ() const { return so3().angleZ(); }
+
+  /// Returns copy of instance casted to NewScalarType.
+  ///
+  template <class NewScalarType>
+  SOPHUS_FUNC SE3<NewScalarType> cast() const {
+    return SE3<NewScalarType>(so3().template cast<NewScalarType>(),
+                              translation().template cast<NewScalarType>());
   }
 
-  /**
-   * \brief Fast group multiplication
-   *
-   * This method is a fast version of operator*=(), since it does not perform
-   * normalization. It is up to the user to call normalize() once in a while.
-   *
-   * \see operator*=()
-   */
-  inline
-  void fastMultiply(const SE3Group<Scalar>& other) {
-    translation() += so3()*(other.translation());
-    so3().fastMultiply(other.so3());
+  /// Returns derivative of  this * exp(x)  wrt x at x=0.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, num_parameters, DoF> Dx_this_mul_exp_x_at_0()
+      const {
+    Matrix<Scalar, num_parameters, DoF> J;
+    Eigen::Quaternion<Scalar> const q = unit_quaternion();
+    Scalar const c0 = Scalar(0.5) * q.w();
+    Scalar const c1 = Scalar(0.5) * q.z();
+    Scalar const c2 = -c1;
+    Scalar const c3 = Scalar(0.5) * q.y();
+    Scalar const c4 = Scalar(0.5) * q.x();
+    Scalar const c5 = -c4;
+    Scalar const c6 = -c3;
+    Scalar const c7 = q.w() * q.w();
+    Scalar const c8 = q.x() * q.x();
+    Scalar const c9 = q.y() * q.y();
+    Scalar const c10 = -c9;
+    Scalar const c11 = q.z() * q.z();
+    Scalar const c12 = -c11;
+    Scalar const c13 = Scalar(2) * q.w();
+    Scalar const c14 = c13 * q.z();
+    Scalar const c15 = Scalar(2) * q.x();
+    Scalar const c16 = c15 * q.y();
+    Scalar const c17 = c13 * q.y();
+    Scalar const c18 = c15 * q.z();
+    Scalar const c19 = c7 - c8;
+    Scalar const c20 = c13 * q.x();
+    Scalar const c21 = Scalar(2) * q.y() * q.z();
+    J(0, 0) = 0;
+    J(0, 1) = 0;
+    J(0, 2) = 0;
+    J(0, 3) = c0;
+    J(0, 4) = c2;
+    J(0, 5) = c3;
+    J(1, 0) = 0;
+    J(1, 1) = 0;
+    J(1, 2) = 0;
+    J(1, 3) = c1;
+    J(1, 4) = c0;
+    J(1, 5) = c5;
+    J(2, 0) = 0;
+    J(2, 1) = 0;
+    J(2, 2) = 0;
+    J(2, 3) = c6;
+    J(2, 4) = c4;
+    J(2, 5) = c0;
+    J(3, 0) = 0;
+    J(3, 1) = 0;
+    J(3, 2) = 0;
+    J(3, 3) = c5;
+    J(3, 4) = c6;
+    J(3, 5) = c2;
+    J(4, 0) = c10 + c12 + c7 + c8;
+    J(4, 1) = -c14 + c16;
+    J(4, 2) = c17 + c18;
+    J(4, 3) = 0;
+    J(4, 4) = 0;
+    J(4, 5) = 0;
+    J(5, 0) = c14 + c16;
+    J(5, 1) = c12 + c19 + c9;
+    J(5, 2) = -c20 + c21;
+    J(5, 3) = 0;
+    J(5, 4) = 0;
+    J(5, 5) = 0;
+    J(6, 0) = -c17 + c18;
+    J(6, 1) = c20 + c21;
+    J(6, 2) = c10 + c11 + c19;
+    J(6, 3) = 0;
+    J(6, 4) = 0;
+    J(6, 5) = 0;
+    return J;
   }
 
-  /**
-   * \returns Group inverse of instance
-   */
-  inline
-  const SE3Group<Scalar> inverse() const {
-    const SO3Group<Scalar> invR = so3().inverse();
-    return SE3Group<Scalar>(invR, invR*(translation()
-                                        *static_cast<Scalar>(-1) ) );
+  /// Returns group inverse.
+  ///
+  SOPHUS_FUNC SE3<Scalar> inverse() const {
+    SO3<Scalar> invR = so3().inverse();
+    return SE3<Scalar>(invR, invR * (translation() * Scalar(-1)));
   }
 
-  /**
-   * \brief Logarithmic map
-   *
-   * \returns tangent space representation
-   *          (translational part and rotation vector) of instance
-   *
-   * \see  log().
-   */
-  inline
-  const Tangent log() const {
-    return log(*this);
+  /// Logarithmic map
+  ///
+  /// Computes the logarithm, the inverse of the group exponential which maps
+  /// element of the group (rigid body transformations) to elements of the
+  /// tangent space (twist).
+  ///
+  /// To be specific, this function computes ``vee(logmat(.))`` with
+  /// ``logmat(.)`` being the matrix logarithm and ``vee(.)`` the vee-operator
+  /// of SE(3).
+  ///
+  SOPHUS_FUNC Tangent log() const {
+    // For the derivation of the logarithm of SE(3), see
+    // J. Gallier, D. Xu, "Computing exponentials of skew symmetric matrices
+    // and logarithms of orthogonal matrices", IJRA 2002.
+    // https:///pdfs.semanticscholar.org/cfe3/e4b39de63c8cabd89bf3feff7f5449fc981d.pdf
+    // (Sec. 6., pp. 8)
+    using std::abs;
+    using std::cos;
+    using std::sin;
+    Tangent upsilon_omega;
+    auto omega_and_theta = so3().logAndTheta();
+    Scalar theta = omega_and_theta.theta;
+    upsilon_omega.template tail<3>() = omega_and_theta.tangent;
+    Matrix3<Scalar> const Omega =
+        SO3<Scalar>::hat(upsilon_omega.template tail<3>());
+
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      Matrix3<Scalar> const V_inv = Matrix3<Scalar>::Identity() -
+                                    Scalar(0.5) * Omega +
+                                    Scalar(1. / 12.) * (Omega * Omega);
+
+      upsilon_omega.template head<3>() = V_inv * translation();
+    } else {
+      Scalar const half_theta = Scalar(0.5) * theta;
+
+      Matrix3<Scalar> const V_inv =
+          (Matrix3<Scalar>::Identity() - Scalar(0.5) * Omega +
+           (Scalar(1) -
+            theta * cos(half_theta) / (Scalar(2) * sin(half_theta))) /
+               (theta * theta) * (Omega * Omega));
+      upsilon_omega.template head<3>() = V_inv * translation();
+    }
+    return upsilon_omega;
   }
 
-  /**
-   * \brief Normalize SO3 element
-   *
-   * It re-normalizes the SO3 element. This method only needs to
-   * be called in conjunction with fastMultiply() or data() write access.
-   */
-  inline
-  void normalize() {
-    so3().normalize();
-  }
+  /// It re-normalizes the SO3 element.
+  ///
+  /// Note: Because of the class invariant of SO3, there is typically no need to
+  /// call this function directly.
+  ///
+  SOPHUS_FUNC void normalize() { so3().normalize(); }
 
-  /**
-   * \returns 4x4 matrix representation of instance
-   */
-  inline
-  const Transformation matrix() const {
+  /// Returns 4x4 matrix representation of the instance.
+  ///
+  /// It has the following form:
+  ///
+  ///   | R t |
+  ///   | o 1 |
+  ///
+  /// where ``R`` is a 3x3 rotation matrix, ``t`` a translation 3-vector and
+  /// ``o`` a 3-column vector of zeros.
+  ///
+  SOPHUS_FUNC Transformation matrix() const {
     Transformation homogenious_matrix;
-    homogenious_matrix.setIdentity();
-    homogenious_matrix.block(0,0,3,3) = rotationMatrix();
-    homogenious_matrix.col(3).head(3) = translation();
+    homogenious_matrix.template topLeftCorner<3, 4>() = matrix3x4();
+    homogenious_matrix.row(3) =
+        Matrix<Scalar, 1, 4>(Scalar(0), Scalar(0), Scalar(0), Scalar(1));
     return homogenious_matrix;
   }
 
-  /**
-   * \returns 3x4 matrix representation of instance
-   *
-   * It returns the three first row of matrix().
-   */
-  inline
-  const Matrix<Scalar,3,4> matrix3x4() const {
-    Matrix<Scalar,3,4> matrix;
-    matrix.block(0,0,3,3) = rotationMatrix();
+  /// Returns the significant first three rows of the matrix above.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, 3, 4> matrix3x4() const {
+    Matrix<Scalar, 3, 4> matrix;
+    matrix.template topLeftCorner<3, 3>() = rotationMatrix();
     matrix.col(3) = translation();
     return matrix;
   }
 
-  /**
-   * \brief Assignment operator
-   */
-  template<typename OtherDerived> inline
-  SE3GroupBase<Derived>& operator= (const SE3GroupBase<OtherDerived> & other) {
+  /// Assignment operator.
+  ///
+  SOPHUS_FUNC SE3Base& operator=(SE3Base const& other) = default;
+
+  /// Assignment-like operator from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC SE3Base<Derived>& operator=(SE3Base<OtherDerived> const& other) {
     so3() = other.so3();
     translation() = other.translation();
     return *this;
   }
 
-  /**
-   * \brief Group multiplication
-   * \see operator*=()
-   */
-  inline
-  const SE3Group<Scalar> operator*(const SE3Group<Scalar>& other) const {
-    SE3Group<Scalar> result(*this);
-    result *= other;
-    return result;
+  /// Group multiplication, which is rotation concatenation.
+  ///
+  template <typename OtherDerived>
+  SOPHUS_FUNC SE3Product<OtherDerived> operator*(
+      SE3Base<OtherDerived> const& other) const {
+    return SE3Product<OtherDerived>(
+        so3() * other.so3(), translation() + so3() * other.translation());
   }
 
-  /**
-   * \brief Group action on \f$ \mathbf{R}^3 \f$
-   *
-   * \param p point \f$p \in \mathbf{R}^3 \f$
-   * \returns point \f$p' \in \mathbf{R}^3 \f$,
-   *          rotated and translated version of \f$p\f$
-   *
-   * This function rotates and translates point \f$ p \f$
-   * in \f$ \mathbf{R}^3 \f$ by the SE3 transformation \f$R,t\f$
-   * (=rotation matrix, translation vector): \f$ p' = R\cdot p + t \f$.
-   */
-  inline
-  const Point operator*(const Point & p) const {
-    return so3()*p + translation();
+  /// Group action on 3-points.
+  ///
+  /// This function rotates and translates a three dimensional point ``p`` by
+  /// the SE(3) element ``bar_T_foo = (bar_R_foo, t_bar)`` (= rigid body
+  /// transformation):
+  ///
+  ///   ``p_bar = bar_R_foo * p_foo + t_bar``.
+  ///
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 3>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
+    return so3() * p + translation();
   }
 
-  /**
-   * \brief In-place group multiplication
-   *
-   * \see fastMultiply()
-   * \see operator*()
-   */
-  inline
-  void operator*=(const SE3Group<Scalar>& other) {
-    fastMultiply(other);
-    normalize();
+  /// Group action on homogeneous 3-points. See above for more details.
+  ///
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 4>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const PointProduct<HPointDerived> tp =
+        so3() * p.template head<3>() + p(3) * translation();
+    return HomogeneousPointProduct<HPointDerived>(tp(0), tp(1), tp(2), p(3));
   }
 
-
-  /**
-   * \returns Rotation matrix
-   *
-   * deprecated: use rotationMatrix() instead.
-   */
-  typedef Transformation M3_marcos_dont_like_commas;
-  inline
-  EIGEN_DEPRECATED const M3_marcos_dont_like_commas rotation_matrix() const {
-    return so3().matrix();
+  /// Group action on lines.
+  ///
+  /// This function rotates and translates a parametrized line
+  /// ``l(t) = o + t * d`` by the SE(3) element:
+  ///
+  /// Origin is transformed using SE(3) action
+  /// Direction is transformed using rotation part
+  ///
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), so3() * l.direction());
   }
 
-  /**
-   * \returns Rotation matrix
-   */
-  inline
-  const Matrix<Scalar,3,3> rotationMatrix() const {
-    return so3().matrix();
+  /// In-place group multiplication. This method is only valid if the return
+  /// type of the multiplication is compatible with this SE3's Scalar type.
+  ///
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC SE3Base<Derived>& operator*=(SE3Base<OtherDerived> const& other) {
+    *static_cast<Derived*>(this) = *this * other;
+    return *this;
   }
 
+  /// Returns rotation matrix.
+  ///
+  SOPHUS_FUNC Matrix3<Scalar> rotationMatrix() const { return so3().matrix(); }
 
-  /**
-   * \brief Mutator of SO3 group
-   */
-  EIGEN_STRONG_INLINE
-  SO3Reference so3() {
-    return static_cast<Derived*>(this)->so3();
-  }
+  /// Mutator of SO3 group.
+  ///
+  SOPHUS_FUNC SO3Type& so3() { return static_cast<Derived*>(this)->so3(); }
 
-  /**
-   * \brief Accessor of SO3 group
-   */
-  EIGEN_STRONG_INLINE
-  ConstSO3Reference so3() const {
+  /// Accessor of SO3 group.
+  ///
+  SOPHUS_FUNC SO3Type const& so3() const {
     return static_cast<const Derived*>(this)->so3();
   }
 
-  /**
-   * \brief Setter of internal unit quaternion representation
-   *
-   * \param quaternion
-   * \pre   the quaternion must not be zero
-   *
-   * The quaternion is normalized to unit length.
-   */
-  inline
-  void setQuaternion(const Quaternion<Scalar> & quat) {
-    return so3().setQuaternion(quat);
+  /// Takes in quaternion, and normalizes it.
+  ///
+  /// Precondition: The quaternion must not be close to zero.
+  ///
+  SOPHUS_FUNC void setQuaternion(Eigen::Quaternion<Scalar> const& quat) {
+    so3().setQuaternion(quat);
   }
 
-  /**
-   * \brief Setter of unit quaternion using rotation matrix
-   *
-   * \param rotation_matrix a 3x3 rotation matrix
-   * \pre   the 3x3 matrix should be orthogonal and have a determinant of 1
-   */
-  inline
-  void setRotationMatrix
-  (const Matrix<Scalar,3,3> & rotation_matrix) {
-    so3().setQuaternion(Quaternion<Scalar>(rotation_matrix));
+  /// Sets ``so3`` using ``rotation_matrix``.
+  ///
+  /// Precondition: ``R`` must be orthogonal and ``det(R)=1``.
+  ///
+  SOPHUS_FUNC void setRotationMatrix(Matrix3<Scalar> const& R) {
+    SOPHUS_ENSURE(isOrthogonal(R), "R is not orthogonal:\n %", R);
+    SOPHUS_ENSURE(R.determinant() > Scalar(0), "det(R) is not positive: %",
+                  R.determinant());
+    so3().setQuaternion(Eigen::Quaternion<Scalar>(R));
   }
 
-  /**
-   * \brief Mutator of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  TranslationReference translation() {
+  /// Returns internal parameters of SE(3).
+  ///
+  /// It returns (q.imag[0], q.imag[1], q.imag[2], q.real, t[0], t[1], t[2]),
+  /// with q being the unit quaternion, t the translation 3-vector.
+  ///
+  SOPHUS_FUNC Sophus::Vector<Scalar, num_parameters> params() const {
+    Sophus::Vector<Scalar, num_parameters> p;
+    p << so3().params(), translation();
+    return p;
+  }
+
+  /// Mutator of translation vector.
+  ///
+  SOPHUS_FUNC TranslationType& translation() {
     return static_cast<Derived*>(this)->translation();
   }
 
-  /**
-   * \brief Accessor of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  ConstTranslationReference translation() const {
-    return static_cast<const Derived*>(this)->translation();
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC TranslationType const& translation() const {
+    return static_cast<Derived const*>(this)->translation();
   }
 
-  /**
-   * \brief Accessor of unit quaternion
-   *
-   * No direct write access is given to ensure the quaternion stays normalized.
-   */
-  inline
-  typename internal::traits<Derived>::SO3Type::ConstQuaternionReference
-  unit_quaternion() const {
-    return so3().unit_quaternion();
+  /// Accessor of unit quaternion.
+  ///
+  SOPHUS_FUNC QuaternionType const& unit_quaternion() const {
+    return this->so3().unit_quaternion();
+  }
+};
+
+/// SE3 using default storage; derived from SE3Base.
+template <class Scalar_, int Options>
+class SE3 : public SE3Base<SE3<Scalar_, Options>> {
+  using Base = SE3Base<SE3<Scalar_, Options>>;
+
+ public:
+  static int constexpr DoF = Base::DoF;
+  static int constexpr num_parameters = Base::num_parameters;
+
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+  using SO3Member = SO3<Scalar, Options>;
+  using TranslationMember = Vector3<Scalar, Options>;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// Default constructor initializes rigid body motion to the identity.
+  ///
+  SOPHUS_FUNC SE3();
+
+  /// Copy constructor
+  ///
+  SOPHUS_FUNC SE3(SE3 const& other) = default;
+
+  /// Copy-like constructor from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC SE3(SE3Base<OtherDerived> const& other)
+      : so3_(other.so3()), translation_(other.translation()) {
+    static_assert(std::is_same<typename OtherDerived::Scalar, Scalar>::value,
+                  "must be same Scalar type");
   }
 
-  ////////////////////////////////////////////////////////////////////////////
-  // public static functions
-  ////////////////////////////////////////////////////////////////////////////
-
-  /**
-   * \param   b 6-vector representation of Lie algebra element
-   * \returns   derivative of Lie bracket
-   *
-   * This function returns \f$ \frac{\partial}{\partial a} [a, b]_{se3} \f$
-   * with \f$ [a, b]_{se3} \f$ being the lieBracket() of the Lie algebra se3.
-   *
-   * \see lieBracket()
-   */
-  inline static
-  const Adjoint d_lieBracketab_by_d_a(const Tangent & b) {
-    Adjoint res;
-    res.setZero();
-
-    const Matrix<Scalar,3,1> & upsilon2 = b.template head<3>();
-    const Matrix<Scalar,3,1> & omega2 = b.template tail<3>();
-
-    res.template topLeftCorner<3,3>() = -SO3Group<Scalar>::hat(omega2);
-    res.template topRightCorner<3,3>() = -SO3Group<Scalar>::hat(upsilon2);
-    res.template bottomRightCorner<3,3>() = -SO3Group<Scalar>::hat(omega2);
-    return res;
+  /// Constructor from SO3 and translation vector
+  ///
+  template <class OtherDerived, class D>
+  SOPHUS_FUNC SE3(SO3Base<OtherDerived> const& so3,
+                  Eigen::MatrixBase<D> const& translation)
+      : so3_(so3), translation_(translation) {
+    static_assert(std::is_same<typename OtherDerived::Scalar, Scalar>::value,
+                  "must be same Scalar type");
+    static_assert(std::is_same<typename D::Scalar, Scalar>::value,
+                  "must be same Scalar type");
   }
 
-  /**
-   * \brief Group exponential
-   *
-   * \param a tangent space element (6-vector)
-   * \returns corresponding element of the group SE3
-   *
-   * The first three components of \f$ a \f$ represent the translational
-   * part \f$ \upsilon \f$ in the tangent space of SE3, while the last three
-   * components of \f$ a \f$ represents the rotation vector \f$ \omega \f$.
-   *
-   * To be more specific, this function computes \f$ \exp(\widehat{a}) \f$
-   * with \f$ \exp(\cdot) \f$ being the matrix exponential
-   * and \f$ \widehat{\cdot} \f$ the hat()-operator of SE3.
-   *
-   * \see hat()
-   * \see log()
-   */
-  inline static
-  const SE3Group<Scalar> exp(const Tangent & a) {
-    const Matrix<Scalar,3,1> & omega = a.template tail<3>();
+  /// Constructor from rotation matrix and translation vector
+  ///
+  /// Precondition: Rotation matrix needs to be orthogonal with determinant
+  ///               of 1.
+  ///
+  SOPHUS_FUNC
+  SE3(Matrix3<Scalar> const& rotation_matrix, Point const& translation)
+      : so3_(rotation_matrix), translation_(translation) {}
+
+  /// Constructor from quaternion and translation vector.
+  ///
+  /// Precondition: ``quaternion`` must not be close to zero.
+  ///
+  SOPHUS_FUNC SE3(Eigen::Quaternion<Scalar> const& quaternion,
+                  Point const& translation)
+      : so3_(quaternion), translation_(translation) {}
+
+  /// Constructor from 4x4 matrix
+  ///
+  /// Precondition: Rotation matrix needs to be orthogonal with determinant
+  ///               of 1. The last row must be ``(0, 0, 0, 1)``.
+  ///
+  SOPHUS_FUNC explicit SE3(Matrix4<Scalar> const& T)
+      : so3_(T.template topLeftCorner<3, 3>()),
+        translation_(T.template block<3, 1>(0, 3)) {
+    SOPHUS_ENSURE((T.row(3) - Matrix<Scalar, 1, 4>(Scalar(0), Scalar(0),
+                                                   Scalar(0), Scalar(1)))
+                          .squaredNorm() < Constants<Scalar>::epsilon(),
+                  "Last row is not (0,0,0,1), but (%).", T.row(3));
+  }
+
+  /// This provides unsafe read/write access to internal data. SO(3) is
+  /// represented by an Eigen::Quaternion (four parameters). When using direct
+  /// write access, the user needs to take care of that the quaternion stays
+  /// normalized.
+  ///
+  SOPHUS_FUNC Scalar* data() {
+    // so3_ and translation_ are laid out sequentially with no padding
+    return so3_.data();
+  }
+
+  /// Const version of data() above.
+  ///
+  SOPHUS_FUNC Scalar const* data() const {
+    // so3_ and translation_ are laid out sequentially with no padding
+    return so3_.data();
+  }
+
+  /// Accessor of SO3
+  ///
+  SOPHUS_FUNC SO3Member& so3() { return so3_; }
+
+  /// Mutator of SO3
+  ///
+  SOPHUS_FUNC SO3Member const& so3() const { return so3_; }
+
+  /// Mutator of translation vector
+  ///
+  SOPHUS_FUNC TranslationMember& translation() { return translation_; }
+
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC TranslationMember const& translation() const {
+    return translation_;
+  }
+
+  /// Returns derivative of exp(x) wrt. x.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
+      Tangent const& upsilon_omega) {
+    using std::cos;
+    using std::pow;
+    using std::sin;
+    using std::sqrt;
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    Sophus::Vector<Scalar, 3> upsilon = upsilon_omega.template head<3>();
+    Sophus::Vector<Scalar, 3> omega = upsilon_omega.template tail<3>();
+
+    Scalar const c0 = omega[0] * omega[0];
+    Scalar const c1 = omega[1] * omega[1];
+    Scalar const c2 = omega[2] * omega[2];
+    Scalar const c3 = c0 + c1 + c2;
+    Scalar const o(0);
+    Scalar const h(0.5);
+    Scalar const i(1);
+
+    if (c3 < Constants<Scalar>::epsilon()) {
+      Scalar const ux = Scalar(0.5) * upsilon[0];
+      Scalar const uy = Scalar(0.5) * upsilon[1];
+      Scalar const uz = Scalar(0.5) * upsilon[2];
+
+      /// clang-format off
+      J << o, o, o, h, o, o, o, o, o, o, h, o, o, o, o, o, o, h, o, o, o, o, o,
+          o, i, o, o, o, uz, -uy, o, i, o, -uz, o, ux, o, o, i, uy, -ux, o;
+      /// clang-format on
+      return J;
+    }
+
+    Scalar const c4 = sqrt(c3);
+    Scalar const c5 = Scalar(1.0) / c4;
+    Scalar const c6 = Scalar(0.5) * c4;
+    Scalar const c7 = sin(c6);
+    Scalar const c8 = c5 * c7;
+    Scalar const c9 = pow(c3, -3.0L / 2.0L);
+    Scalar const c10 = c7 * c9;
+    Scalar const c11 = Scalar(1.0) / c3;
+    Scalar const c12 = cos(c6);
+    Scalar const c13 = Scalar(0.5) * c11 * c12;
+    Scalar const c14 = c7 * c9 * omega[0];
+    Scalar const c15 = Scalar(0.5) * c11 * c12 * omega[0];
+    Scalar const c16 = -c14 * omega[1] + c15 * omega[1];
+    Scalar const c17 = -c14 * omega[2] + c15 * omega[2];
+    Scalar const c18 = omega[1] * omega[2];
+    Scalar const c19 = -c10 * c18 + c13 * c18;
+    Scalar const c20 = c5 * omega[0];
+    Scalar const c21 = Scalar(0.5) * c7;
+    Scalar const c22 = c5 * omega[1];
+    Scalar const c23 = c5 * omega[2];
+    Scalar const c24 = -c1;
+    Scalar const c25 = -c2;
+    Scalar const c26 = c24 + c25;
+    Scalar const c27 = sin(c4);
+    Scalar const c28 = -c27 + c4;
+    Scalar const c29 = c28 * c9;
+    Scalar const c30 = cos(c4);
+    Scalar const c31 = -c30 + Scalar(1);
+    Scalar const c32 = c11 * c31;
+    Scalar const c33 = c32 * omega[2];
+    Scalar const c34 = c29 * omega[0];
+    Scalar const c35 = c34 * omega[1];
+    Scalar const c36 = c32 * omega[1];
+    Scalar const c37 = c34 * omega[2];
+    Scalar const c38 = pow(c3, -5.0L / 2.0L);
+    Scalar const c39 = Scalar(3) * c28 * c38 * omega[0];
+    Scalar const c40 = c26 * c9;
+    Scalar const c41 = -c20 * c30 + c20;
+    Scalar const c42 = c27 * c9 * omega[0];
+    Scalar const c43 = c42 * omega[1];
+    Scalar const c44 = pow(c3, -2);
+    Scalar const c45 = Scalar(2) * c31 * c44 * omega[0];
+    Scalar const c46 = c45 * omega[1];
+    Scalar const c47 = c29 * omega[2];
+    Scalar const c48 = c43 - c46 + c47;
+    Scalar const c49 = Scalar(3) * c0 * c28 * c38;
+    Scalar const c50 = c9 * omega[0] * omega[2];
+    Scalar const c51 = c41 * c50 - c49 * omega[2];
+    Scalar const c52 = c9 * omega[0] * omega[1];
+    Scalar const c53 = c41 * c52 - c49 * omega[1];
+    Scalar const c54 = c42 * omega[2];
+    Scalar const c55 = c45 * omega[2];
+    Scalar const c56 = c29 * omega[1];
+    Scalar const c57 = -c54 + c55 + c56;
+    Scalar const c58 = Scalar(-2) * c56;
+    Scalar const c59 = Scalar(3) * c28 * c38 * omega[1];
+    Scalar const c60 = -c22 * c30 + c22;
+    Scalar const c61 = -c18 * c39;
+    Scalar const c62 = c32 + c61;
+    Scalar const c63 = c27 * c9;
+    Scalar const c64 = c1 * c63;
+    Scalar const c65 = Scalar(2) * c31 * c44;
+    Scalar const c66 = c1 * c65;
+    Scalar const c67 = c50 * c60;
+    Scalar const c68 = -c1 * c39 + c52 * c60;
+    Scalar const c69 = c18 * c63;
+    Scalar const c70 = c18 * c65;
+    Scalar const c71 = c34 - c69 + c70;
+    Scalar const c72 = Scalar(-2) * c47;
+    Scalar const c73 = Scalar(3) * c28 * c38 * omega[2];
+    Scalar const c74 = -c23 * c30 + c23;
+    Scalar const c75 = -c32 + c61;
+    Scalar const c76 = c2 * c63;
+    Scalar const c77 = c2 * c65;
+    Scalar const c78 = c52 * c74;
+    Scalar const c79 = c34 + c69 - c70;
+    Scalar const c80 = -c2 * c39 + c50 * c74;
+    Scalar const c81 = -c0;
+    Scalar const c82 = c25 + c81;
+    Scalar const c83 = c32 * omega[0];
+    Scalar const c84 = c18 * c29;
+    Scalar const c85 = Scalar(-2) * c34;
+    Scalar const c86 = c82 * c9;
+    Scalar const c87 = c0 * c63;
+    Scalar const c88 = c0 * c65;
+    Scalar const c89 = c9 * omega[1] * omega[2];
+    Scalar const c90 = c41 * c89;
+    Scalar const c91 = c54 - c55 + c56;
+    Scalar const c92 = -c1 * c73 + c60 * c89;
+    Scalar const c93 = -c43 + c46 + c47;
+    Scalar const c94 = -c2 * c59 + c74 * c89;
+    Scalar const c95 = c24 + c81;
+    Scalar const c96 = c9 * c95;
+    J(0, 0) = o;
+    J(0, 1) = o;
+    J(0, 2) = o;
+    J(0, 3) = -c0 * c10 + c0 * c13 + c8;
+    J(0, 4) = c16;
+    J(0, 5) = c17;
+    J(1, 0) = o;
+    J(1, 1) = o;
+    J(1, 2) = o;
+    J(1, 3) = c16;
+    J(1, 4) = -c1 * c10 + c1 * c13 + c8;
+    J(1, 5) = c19;
+    J(2, 0) = o;
+    J(2, 1) = o;
+    J(2, 2) = o;
+    J(2, 3) = c17;
+    J(2, 4) = c19;
+    J(2, 5) = -c10 * c2 + c13 * c2 + c8;
+    J(3, 0) = o;
+    J(3, 1) = o;
+    J(3, 2) = o;
+    J(3, 3) = -c20 * c21;
+    J(3, 4) = -c21 * c22;
+    J(3, 5) = -c21 * c23;
+    J(4, 0) = c26 * c29 + Scalar(1);
+    J(4, 1) = -c33 + c35;
+    J(4, 2) = c36 + c37;
+    J(4, 3) = upsilon[0] * (-c26 * c39 + c40 * c41) + upsilon[1] * (c53 + c57) +
+              upsilon[2] * (c48 + c51);
+    J(4, 4) = upsilon[0] * (-c26 * c59 + c40 * c60 + c58) +
+              upsilon[1] * (c68 + c71) + upsilon[2] * (c62 + c64 - c66 + c67);
+    J(4, 5) = upsilon[0] * (-c26 * c73 + c40 * c74 + c72) +
+              upsilon[1] * (c75 - c76 + c77 + c78) + upsilon[2] * (c79 + c80);
+    J(5, 0) = c33 + c35;
+    J(5, 1) = c29 * c82 + Scalar(1);
+    J(5, 2) = -c83 + c84;
+    J(5, 3) = upsilon[0] * (c53 + c91) +
+              upsilon[1] * (-c39 * c82 + c41 * c86 + c85) +
+              upsilon[2] * (c75 - c87 + c88 + c90);
+    J(5, 4) = upsilon[0] * (c68 + c79) + upsilon[1] * (-c59 * c82 + c60 * c86) +
+              upsilon[2] * (c92 + c93);
+    J(5, 5) = upsilon[0] * (c62 + c76 - c77 + c78) +
+              upsilon[1] * (c72 - c73 * c82 + c74 * c86) +
+              upsilon[2] * (c57 + c94);
+    J(6, 0) = -c36 + c37;
+    J(6, 1) = c83 + c84;
+    J(6, 2) = c29 * c95 + Scalar(1);
+    J(6, 3) = upsilon[0] * (c51 + c93) + upsilon[1] * (c62 + c87 - c88 + c90) +
+              upsilon[2] * (-c39 * c95 + c41 * c96 + c85);
+    J(6, 4) = upsilon[0] * (-c64 + c66 + c67 + c75) + upsilon[1] * (c48 + c92) +
+              upsilon[2] * (c58 - c59 * c95 + c60 * c96);
+    J(6, 5) = upsilon[0] * (c71 + c80) + upsilon[1] * (c91 + c94) +
+              upsilon[2] * (-c73 * c95 + c74 * c96);
+
+    return J;
+  }
+
+  /// Returns derivative of exp(x) wrt. x_i at x=0.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF>
+  Dx_exp_x_at_0() {
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    Scalar const o(0);
+    Scalar const h(0.5);
+    Scalar const i(1);
+
+    // clang-format off
+    J << o, o, o, h, o, o, o,
+         o, o, o, h, o, o, o,
+         o, o, o, h, o, o, o,
+         o, o, o, i, o, o, o,
+         o, o, o, i, o, o, o,
+         o, o, o, i, o, o, o;
+    // clang-format on
+    return J;
+  }
+
+  /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.
+  ///
+  SOPHUS_FUNC static Transformation Dxi_exp_x_matrix_at_0(int i) {
+    return generator(i);
+  }
+
+  /// Group exponential
+  ///
+  /// This functions takes in an element of tangent space (= twist ``a``) and
+  /// returns the corresponding element of the group SE(3).
+  ///
+  /// The first three components of ``a`` represent the translational part
+  /// ``upsilon`` in the tangent space of SE(3), while the last three components
+  /// of ``a`` represents the rotation vector ``omega``.
+  /// To be more specific, this function computes ``expmat(hat(a))`` with
+  /// ``expmat(.)`` being the matrix exponential and ``hat(.)`` the hat-operator
+  /// of SE(3), see below.
+  ///
+  SOPHUS_FUNC static SE3<Scalar> exp(Tangent const& a) {
+    using std::cos;
+    using std::sin;
+    Vector3<Scalar> const omega = a.template tail<3>();
 
     Scalar theta;
-    const SO3Group<Scalar> & so3
-        = SO3Group<Scalar>::expAndTheta(omega, &theta);
+    SO3<Scalar> const so3 = SO3<Scalar>::expAndTheta(omega, &theta);
+    Matrix3<Scalar> const Omega = SO3<Scalar>::hat(omega);
+    Matrix3<Scalar> const Omega_sq = Omega * Omega;
+    Matrix3<Scalar> V;
 
-    const Matrix<Scalar,3,3> & Omega = SO3Group<Scalar>::hat(omega);
-    const Matrix<Scalar,3,3> & Omega_sq = Omega*Omega;
-    Matrix<Scalar,3,3> V;
-
-    if(theta<SophusConstants<Scalar>::epsilon()) {
+    if (theta < Constants<Scalar>::epsilon()) {
       V = so3.matrix();
-      //Note: That is an accurate expansion!
+      /// Note: That is an accurate expansion!
     } else {
-      Scalar theta_sq = theta*theta;
-      V = (Matrix<Scalar,3,3>::Identity()
-           + (static_cast<Scalar>(1)-std::cos(theta))/(theta_sq)*Omega
-           + (theta-std::sin(theta))/(theta_sq*theta)*Omega_sq);
+      Scalar theta_sq = theta * theta;
+      V = (Matrix3<Scalar>::Identity() +
+           (Scalar(1) - cos(theta)) / (theta_sq)*Omega +
+           (theta - sin(theta)) / (theta_sq * theta) * Omega_sq);
     }
-    return SE3Group<Scalar>(so3,V*a.template head<3>());
+    return SE3<Scalar>(so3, V * a.template head<3>());
   }
 
-  /**
-   * \brief Generators
-   *
-   * \pre \f$ i \in \{0,1,2,3,4,5\} \f$
-   * \returns \f$ i \f$th generator \f$ G_i \f$ of SE3
-   *
-   * The infinitesimal generators of SE3 are: \f[
-   *        G_0 = \left( \begin{array}{cccc}
-   *                          0&  0&  0&  1\\
-   *                          0&  0&  0&  0\\
-   *                          0&  0&  0&  0\\
-   *                          0&  0&  0&  0\\
-   *                     \end{array} \right),
-   *        G_1 = \left( \begin{array}{cccc}
-   *                          0&  0&  0&  0\\
-   *                          0&  0&  0&  1\\
-   *                          0&  0&  0&  0\\
-   *                          0&  0&  0&  0\\
-   *                     \end{array} \right),
-   *        G_2 = \left( \begin{array}{cccc}
-   *                          0&  0&  0&  0\\
-   *                          0&  0&  0&  0\\
-   *                          0&  0&  0&  1\\
-   *                          0&  0&  0&  0\\
-   *                     \end{array} \right).
-   *        G_3 = \left( \begin{array}{cccc}
-   *                          0&  0&  0&  0\\
-   *                          0&  0& -1&  0\\
-   *                          0&  1&  0&  0\\
-   *                          0&  0&  0&  0\\
-   *                     \end{array} \right),
-   *        G_4 = \left( \begin{array}{cccc}
-   *                          0&  0&  1&  0\\
-   *                          0&  0&  0&  0\\
-   *                         -1&  0&  0&  0\\
-   *                          0&  0&  0&  0\\
-   *                     \end{array} \right),
-   *        G_5 = \left( \begin{array}{cccc}
-   *                          0& -1&  0&  0\\
-   *                          1&  0&  0&  0\\
-   *                          0&  0&  0&  0\\
-   *                          0&  0&  0&  0\\
-   *                     \end{array} \right).
-   * \f]
-   * \see hat()
-   */
-  inline static
-  const Transformation generator(int i) {
-    if (i<0 || i>5) {
-      throw SophusException("i is not in range [0,5].");
-    }
+  /// Returns closest SE3 given arbirary 4x4 matrix.
+  ///
+  template <class S = Scalar>
+  SOPHUS_FUNC static enable_if_t<std::is_floating_point<S>::value, SE3>
+  fitToSE3(Matrix4<Scalar> const& T) {
+    return SE3(SO3<Scalar>::fitToSO3(T.template block<3, 3>(0, 0)),
+               T.template block<3, 1>(0, 3));
+  }
+
+  /// Returns the ith infinitesimal generators of SE(3).
+  ///
+  /// The infinitesimal generators of SE(3) are:
+  ///
+  /// ```
+  ///         |  0  0  0  1 |
+  ///   G_0 = |  0  0  0  0 |
+  ///         |  0  0  0  0 |
+  ///         |  0  0  0  0 |
+  ///
+  ///         |  0  0  0  0 |
+  ///   G_1 = |  0  0  0  1 |
+  ///         |  0  0  0  0 |
+  ///         |  0  0  0  0 |
+  ///
+  ///         |  0  0  0  0 |
+  ///   G_2 = |  0  0  0  0 |
+  ///         |  0  0  0  1 |
+  ///         |  0  0  0  0 |
+  ///
+  ///         |  0  0  0  0 |
+  ///   G_3 = |  0  0 -1  0 |
+  ///         |  0  1  0  0 |
+  ///         |  0  0  0  0 |
+  ///
+  ///         |  0  0  1  0 |
+  ///   G_4 = |  0  0  0  0 |
+  ///         | -1  0  0  0 |
+  ///         |  0  0  0  0 |
+  ///
+  ///         |  0 -1  0  0 |
+  ///   G_5 = |  1  0  0  0 |
+  ///         |  0  0  0  0 |
+  ///         |  0  0  0  0 |
+  /// ```
+  ///
+  /// Precondition: ``i`` must be in [0, 5].
+  ///
+  SOPHUS_FUNC static Transformation generator(int i) {
+    SOPHUS_ENSURE(i >= 0 && i <= 5, "i should be in range [0,5].");
     Tangent e;
     e.setZero();
-    e[i] = static_cast<Scalar>(1);
+    e[i] = Scalar(1);
     return hat(e);
   }
 
-  /**
-   * \brief hat-operator
-   *
-   * \param omega 6-vector representation of Lie algebra element
-   * \returns     4x4-matrix representatin of Lie algebra element
-   *
-   * Formally, the hat-operator of SE3 is defined
-   * as \f$ \widehat{\cdot}: \mathbf{R}^6 \rightarrow \mathbf{R}^{4\times 4},
-   * \quad \widehat{\omega} = \sum_{i=0}^5 G_i \omega_i \f$
-   * with \f$ G_i \f$ being the ith infinitesial generator().
-   *
-   * \see generator()
-   * \see vee()
-   */
-  inline static
-  const Transformation hat(const Tangent & v) {
+  /// hat-operator
+  ///
+  /// It takes in the 6-vector representation (= twist) and returns the
+  /// corresponding matrix representation of Lie algebra element.
+  ///
+  /// Formally, the hat()-operator of SE(3) is defined as
+  ///
+  ///   ``hat(.): R^6 -> R^{4x4},  hat(a) = sum_i a_i * G_i``  (for i=0,...,5)
+  ///
+  /// with ``G_i`` being the ith infinitesimal generator of SE(3).
+  ///
+  /// The corresponding inverse is the vee()-operator, see below.
+  ///
+  SOPHUS_FUNC static Transformation hat(Tangent const& a) {
     Transformation Omega;
     Omega.setZero();
-    Omega.template topLeftCorner<3,3>()
-        = SO3Group<Scalar>::hat(v.template tail<3>());
-    Omega.col(3).template head<3>() = v.template head<3>();
+    Omega.template topLeftCorner<3, 3>() =
+        SO3<Scalar>::hat(a.template tail<3>());
+    Omega.col(3).template head<3>() = a.template head<3>();
     return Omega;
   }
 
-  /**
-   * \brief Lie bracket
-   *
-   * \param a 6-vector representation of Lie algebra element
-   * \param b 6-vector representation of Lie algebra element
-   * \returns      6-vector representation of Lie algebra element
-   *
-   * It computes the bracket of SE3. To be more specific, it
-   * computes \f$ [a, b]_{se3}
-   * := [\widehat{a}, \widehat{b}]^\vee \f$
-   * with \f$ [A,B] = AB-BA \f$ being the matrix
-   * commutator, \f$ \widehat{\cdot} \f$ the
-   * hat()-operator and \f$ (\cdot)^\vee \f$ the vee()-operator of SE3.
-   *
-   * \see hat()
-   * \see vee()
-   */
-  inline static
-  const Tangent lieBracket(const Tangent & a,
-                           const Tangent & b) {
-    Matrix<Scalar,3,1> upsilon1 = a.template head<3>();
-    Matrix<Scalar,3,1> upsilon2 = b.template head<3>();
-    Matrix<Scalar,3,1> omega1 = a.template tail<3>();
-    Matrix<Scalar,3,1> omega2 = b.template tail<3>();
+  /// Lie bracket
+  ///
+  /// It computes the Lie bracket of SE(3). To be more specific, it computes
+  ///
+  ///   ``[omega_1, omega_2]_se3 := vee([hat(omega_1), hat(omega_2)])``
+  ///
+  /// with ``[A,B] := AB-BA`` being the matrix commutator, ``hat(.)`` the
+  /// hat()-operator and ``vee(.)`` the vee()-operator of SE(3).
+  ///
+  SOPHUS_FUNC static Tangent lieBracket(Tangent const& a, Tangent const& b) {
+    Vector3<Scalar> const upsilon1 = a.template head<3>();
+    Vector3<Scalar> const upsilon2 = b.template head<3>();
+    Vector3<Scalar> const omega1 = a.template tail<3>();
+    Vector3<Scalar> const omega2 = b.template tail<3>();
 
     Tangent res;
     res.template head<3>() = omega1.cross(upsilon2) + upsilon1.cross(omega2);
@@ -540,408 +882,200 @@ public:
     return res;
   }
 
-  /**
-   * \brief Logarithmic map
-   *
-   * \param other element of the group SE3
-   * \returns     corresponding tangent space element
-   *              (translational part \f$ \upsilon \f$
-   *               and rotation vector \f$ \omega \f$)
-   *
-   * Computes the logarithmic, the inverse of the group exponential.
-   * To be specific, this function computes \f$ \log({\cdot})^\vee \f$
-   * with \f$ \vee(\cdot) \f$ being the matrix logarithm
-   * and \f$ \vee{\cdot} \f$ the vee()-operator of SE3.
-   *
-   * \see exp()
-   * \see vee()
-   */
-  inline static
-  const Tangent log(const SE3Group<Scalar> & se3) {
-    Tangent upsilon_omega;
-    Scalar theta;
-    upsilon_omega.template tail<3>()
-        = SO3Group<Scalar>::logAndTheta(se3.so3(), &theta);
-
-    if (std::abs(theta)<SophusConstants<Scalar>::epsilon()) {
-      const Matrix<Scalar,3,3> & Omega
-          = SO3Group<Scalar>::hat(upsilon_omega.template tail<3>());
-      const Matrix<Scalar,3,3> & V_inv =
-          Matrix<Scalar,3,3>::Identity() -
-          static_cast<Scalar>(0.5)*Omega
-          + static_cast<Scalar>(1./12.)*(Omega*Omega);
-
-      upsilon_omega.template head<3>() = V_inv*se3.translation();
-    } else {
-      const Matrix<Scalar,3,3> & Omega
-          = SO3Group<Scalar>::hat(upsilon_omega.template tail<3>());
-      const Matrix<Scalar,3,3> & V_inv =
-          ( Matrix<Scalar,3,3>::Identity() - static_cast<Scalar>(0.5)*Omega
-            + ( static_cast<Scalar>(1)
-                - theta/(static_cast<Scalar>(2)*tan(theta/Scalar(2)))) /
-            (theta*theta)*(Omega*Omega) );
-      upsilon_omega.template head<3>() = V_inv*se3.translation();
-    }
-    return upsilon_omega;
+  /// Construct x-axis rotation.
+  ///
+  static SOPHUS_FUNC SE3 rotX(Scalar const& x) {
+    return SE3(SO3<Scalar>::rotX(x), Sophus::Vector3<Scalar>::Zero());
   }
 
-  /**
-   * \brief vee-operator
-   *
-   * \param Omega 4x4-matrix representation of Lie algebra element
-   * \returns     6-vector representatin of Lie algebra element
-   *
-   * This is the inverse of the hat()-operator.
-   *
-   * \see hat()
-   */
-  inline static
-  const Tangent vee(const Transformation & Omega) {
+  /// Construct y-axis rotation.
+  ///
+  static SOPHUS_FUNC SE3 rotY(Scalar const& y) {
+    return SE3(SO3<Scalar>::rotY(y), Sophus::Vector3<Scalar>::Zero());
+  }
+
+  /// Construct z-axis rotation.
+  ///
+  static SOPHUS_FUNC SE3 rotZ(Scalar const& z) {
+    return SE3(SO3<Scalar>::rotZ(z), Sophus::Vector3<Scalar>::Zero());
+  }
+
+  /// Draw uniform sample from SE(3) manifold.
+  ///
+  /// Translations are drawn component-wise from the range [-1, 1].
+  ///
+  template <class UniformRandomBitGenerator>
+  static SE3 sampleUniform(UniformRandomBitGenerator& generator) {
+    std::uniform_real_distribution<Scalar> uniform(Scalar(-1), Scalar(1));
+    return SE3(SO3<Scalar>::sampleUniform(generator),
+               Vector3<Scalar>(uniform(generator), uniform(generator),
+                               uniform(generator)));
+  }
+
+  /// Construct a translation only SE3 instance.
+  ///
+  template <class T0, class T1, class T2>
+  static SOPHUS_FUNC SE3 trans(T0 const& x, T1 const& y, T2 const& z) {
+    return SE3(SO3<Scalar>(), Vector3<Scalar>(x, y, z));
+  }
+
+  static SOPHUS_FUNC SE3 trans(Vector3<Scalar> const& xyz) {
+    return SE3(SO3<Scalar>(), xyz);
+  }
+
+  /// Construct x-axis translation.
+  ///
+  static SOPHUS_FUNC SE3 transX(Scalar const& x) {
+    return SE3::trans(x, Scalar(0), Scalar(0));
+  }
+
+  /// Construct y-axis translation.
+  ///
+  static SOPHUS_FUNC SE3 transY(Scalar const& y) {
+    return SE3::trans(Scalar(0), y, Scalar(0));
+  }
+
+  /// Construct z-axis translation.
+  ///
+  static SOPHUS_FUNC SE3 transZ(Scalar const& z) {
+    return SE3::trans(Scalar(0), Scalar(0), z);
+  }
+
+  /// vee-operator
+  ///
+  /// It takes 4x4-matrix representation ``Omega`` and maps it to the
+  /// corresponding 6-vector representation of Lie algebra.
+  ///
+  /// This is the inverse of the hat()-operator, see above.
+  ///
+  /// Precondition: ``Omega`` must have the following structure:
+  ///
+  ///                |  0 -f  e  a |
+  ///                |  f  0 -d  b |
+  ///                | -e  d  0  c
+  ///                |  0  0  0  0 | .
+  ///
+  SOPHUS_FUNC static Tangent vee(Transformation const& Omega) {
     Tangent upsilon_omega;
     upsilon_omega.template head<3>() = Omega.col(3).template head<3>();
-    upsilon_omega.template tail<3>()
-        = SO3Group<Scalar>::vee(Omega.template topLeftCorner<3,3>());
+    upsilon_omega.template tail<3>() =
+        SO3<Scalar>::vee(Omega.template topLeftCorner<3, 3>());
     return upsilon_omega;
   }
+
+ protected:
+  SO3Member so3_;
+  TranslationMember translation_;
 };
 
-/**
- * \brief SE3 default type - Constructors and default storage for SE3 Type
- */
-template<typename _Scalar, int _Options>
-class SE3Group : public SE3GroupBase<SE3Group<_Scalar,_Options> > {
-  typedef SE3GroupBase<SE3Group<_Scalar,_Options> > Base;
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<SE3Group<_Scalar,_Options> >
-  ::Scalar Scalar;
-  /** \brief SO3 reference type */
-  typedef typename internal::traits<SE3Group<_Scalar,_Options> >
-  ::SO3Type & SO3Reference;
-  /** \brief SO3 const reference type */
-  typedef const typename internal::traits<SE3Group<_Scalar,_Options> >
-  ::SO3Type & ConstSO3Reference;
-  /** \brief translation reference type */
-  typedef typename internal::traits<SE3Group<_Scalar,_Options> >
-  ::TranslationType & TranslationReference;
-  /** \brief translation const reference type */
-  typedef const typename internal::traits<SE3Group<_Scalar,_Options> >
-  ::TranslationType & ConstTranslationReference;
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
-
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-  /**
-   * \brief Default constructor
-   *
-   * Initialize Quaternion to identity rotation and translation to zero.
-   */
-  inline
-  SE3Group()
-    : translation_( Matrix<Scalar,3,1>::Zero() )
-  {
-  }
-
-  /**
-   * \brief Copy constructor
-   */
-  template<typename OtherDerived> inline
-  SE3Group(const SE3GroupBase<OtherDerived> & other)
-    : so3_(other.so3()), translation_(other.translation()) {
-  }
-
-  /**
-   * \brief Constructor from SO3 and translation vector
-   */
-  template<typename OtherDerived> inline
-  SE3Group(const SO3GroupBase<OtherDerived> & so3,
-           const Point & translation)
-    : so3_(so3), translation_(translation) {
-  }
-
-  /**
-   * \brief Constructor from rotation matrix and translation vector
-   *
-   * \pre rotation matrix need to be orthogonal with determinant of 1
-   */
-  inline
-  SE3Group(const Matrix<Scalar,3,3> & rotation_matrix,
-           const Point & translation)
-    : so3_(rotation_matrix), translation_(translation) {
-  }
-
-  /**
-   * \brief Constructor from quaternion and translation vector
-   *
-   * \pre quaternion must not be zero
-   */
-  inline
-  SE3Group(const Quaternion<Scalar> & quaternion,
-           const Point & translation)
-    : so3_(quaternion), translation_(translation) {
-  }
-
-  /**
-   * \brief Constructor from 4x4 matrix
-   *
-   * \pre top-left 3x3 sub-matrix need to be orthogonal with determinant of 1
-   */
-  inline explicit
-  SE3Group(const Eigen::Matrix<Scalar,4,4>& T)
-    : so3_(T.template topLeftCorner<3,3>()),
-      translation_(T.template block<3,1>(0,3)) {
-  }
-
-  /**
-   * \returns pointer to internal data
-   *
-   * This provides unsafe read/write access to internal data. SE3 is represented
-   * by a pair of an SO3 element (4 parameters) and translation vector (three
-   * parameters). The user needs to take care of that the quaternion
-   * stays normalized.
-   *
-   * Note: The first three Scalars represent the imaginary parts, while the
-   * forth Scalar represent the real part.
-   *
-   * /see normalize()
-   */
-  EIGEN_STRONG_INLINE
-  Scalar* data() {
-    // so3_ and translation_ are layed out sequentially with no padding
-    return so3_.data();
-  }
-
-  /**
-   * \returns const pointer to internal data
-   *
-   * Const version of data().
-   */
-  EIGEN_STRONG_INLINE
-  const Scalar* data() const {
-    // so3_ and translation_ are layed out sequentially with no padding
-    return so3_.data();
-  }
-
-  /**
-   * \brief Accessor of SO3
-   */
-  EIGEN_STRONG_INLINE
-  SO3Reference so3() {
-    return so3_;
-  }
-
-  /**
-   * \brief Mutator of SO3
-   */
-  EIGEN_STRONG_INLINE
-  ConstSO3Reference so3() const {
-    return so3_;
-  }
-
-  /**
-   * \brief Mutator of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  TranslationReference translation() {
-    return translation_;
-  }
-
-  /**
-   * \brief Accessor of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  ConstTranslationReference translation() const {
-    return translation_;
-  }
-
-protected:
-  Sophus::SO3Group<Scalar> so3_;
-  Matrix<Scalar,3,1> translation_;
-};
-
-
-} // end namespace
-
+template <class Scalar, int Options>
+SE3<Scalar, Options>::SE3() : translation_(TranslationMember::Zero()) {
+  static_assert(std::is_standard_layout<SE3>::value,
+                "Assume standard layout for the use of offsetof check below.");
+  static_assert(
+      offsetof(SE3, so3_) + sizeof(Scalar) * SO3<Scalar>::num_parameters ==
+          offsetof(SE3, translation_),
+      "This class assumes packed storage and hence will only work "
+      "correctly depending on the compiler (options) - in "
+      "particular when using [this->data(), this-data() + "
+      "num_parameters] to access the raw data in a contiguous fashion.");
+}
+}  // namespace Sophus
 
 namespace Eigen {
-/**
- * \brief Specialisation of Eigen::Map for SE3GroupBase
- *
- * Allows us to wrap SE3 Objects around POD array
- * (e.g. external c style quaternion)
- */
-template<typename _Scalar, int _Options>
-class Map<Sophus::SE3Group<_Scalar>, _Options>
-    : public Sophus::SE3GroupBase<Map<Sophus::SE3Group<_Scalar>, _Options> > {
-  typedef Sophus::SE3GroupBase<Map<Sophus::SE3Group<_Scalar>, _Options> > Base;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief translation reference type */
-  typedef typename internal::traits<Map>::TranslationType &
-  TranslationReference;
-  /** \brief translation const reference type */
-  typedef const typename internal::traits<Map>::TranslationType &
-  ConstTranslationReference;
-  /** \brief SO3 reference type */
-  typedef typename internal::traits<Map>::SO3Type &
-  SO3Reference;
-  /** \brief SO3 const reference type */
-  typedef const typename internal::traits<Map>::SO3Type &
-  ConstSO3Reference;
+/// Specialization of Eigen::Map for ``SE3``; derived from SE3Base.
+///
+/// Allows us to wrap SE3 objects around POD array.
+template <class Scalar_, int Options>
+class Map<Sophus::SE3<Scalar_>, Options>
+    : public Sophus::SE3Base<Map<Sophus::SE3<Scalar_>, Options>> {
+ public:
+  using Base = Sophus::SE3Base<Map<Sophus::SE3<Scalar_>, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
+  // LCOV_EXCL_START
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  // LCOV_EXCL_STOP
 
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(Scalar* coeffs)
-    : so3_(coeffs),
-      translation_(coeffs+Sophus::SO3Group<Scalar>::num_parameters) {
-  }
+  SOPHUS_FUNC Map(Scalar* coeffs)
+      : so3_(coeffs),
+        translation_(coeffs + Sophus::SO3<Scalar>::num_parameters) {}
 
-  /**
-   * \brief Mutator of SO3
-   */
-  EIGEN_STRONG_INLINE
-  SO3Reference so3() {
+  /// Mutator of SO3
+  ///
+  SOPHUS_FUNC Map<Sophus::SO3<Scalar>, Options>& so3() { return so3_; }
+
+  /// Accessor of SO3
+  ///
+  SOPHUS_FUNC Map<Sophus::SO3<Scalar>, Options> const& so3() const {
     return so3_;
   }
 
-  /**
-   * \brief Accessor of SO3
-   */
-  EIGEN_STRONG_INLINE
-  ConstSO3Reference so3() const {
-    return so3_;
-  }
-
-  /**
-   * \brief Mutator of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  TranslationReference translation() {
+  /// Mutator of translation vector
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector3<Scalar, Options>>& translation() {
     return translation_;
   }
 
-  /**
-   * \brief Accessor of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  ConstTranslationReference translation() const {
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector3<Scalar, Options>> const& translation() const {
     return translation_;
   }
 
-protected:
-  Map<Sophus::SO3Group<Scalar>,_Options> so3_;
-  Map<Matrix<Scalar,3,1>,_Options> translation_;
+ protected:
+  Map<Sophus::SO3<Scalar>, Options> so3_;
+  Map<Sophus::Vector3<Scalar>, Options> translation_;
 };
 
-/**
- * \brief Specialisation of Eigen::Map for const SE3GroupBase
- *
- * Allows us to wrap SE3 Objects around POD array
- * (e.g. external c style quaternion)
- */
-template<typename _Scalar, int _Options>
-class Map<const Sophus::SE3Group<_Scalar>, _Options>
-    : public Sophus::SE3GroupBase<
-    Map<const Sophus::SE3Group<_Scalar>, _Options> > {
-  typedef Sophus::SE3GroupBase<Map<const Sophus::SE3Group<_Scalar>, _Options> >
-  Base;
+/// Specialization of Eigen::Map for ``SE3 const``; derived from SE3Base.
+///
+/// Allows us to wrap SE3 objects around POD array.
+template <class Scalar_, int Options>
+class Map<Sophus::SE3<Scalar_> const, Options>
+    : public Sophus::SE3Base<Map<Sophus::SE3<Scalar_> const, Options>> {
+ public:
+  using Base = Sophus::SE3Base<Map<Sophus::SE3<Scalar_> const, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief translation const reference type */
-  typedef const typename internal::traits<Map>::TranslationType &
-  ConstTranslationReference;
-  /** \brief SO3 const reference type */
-  typedef const typename internal::traits<Map>::SO3Type &
-  ConstSO3Reference;
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(const Scalar* coeffs)
-    : so3_(coeffs),
-      translation_(coeffs+Sophus::SO3Group<Scalar>::num_parameters) {
-  }
+  SOPHUS_FUNC Map(Scalar const* coeffs)
+      : so3_(coeffs),
+        translation_(coeffs + Sophus::SO3<Scalar>::num_parameters) {}
 
-  EIGEN_STRONG_INLINE
-  Map(const Scalar* trans_coeffs, const Scalar* rot_coeffs)
-    : translation_(trans_coeffs), so3_(rot_coeffs){
-  }
-
-  /**
-   * \brief Accessor of SO3
-   */
-  EIGEN_STRONG_INLINE
-  ConstSO3Reference so3() const {
+  /// Accessor of SO3
+  ///
+  SOPHUS_FUNC Map<Sophus::SO3<Scalar> const, Options> const& so3() const {
     return so3_;
   }
 
-  /**
-   * \brief Accessor of translation vector
-   */
-  EIGEN_STRONG_INLINE
-  ConstTranslationReference translation() const {
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector3<Scalar> const, Options> const& translation()
+      const {
     return translation_;
   }
 
-protected:
-  const Map<const Sophus::SO3Group<Scalar>,_Options> so3_;
-  const Map<const Matrix<Scalar,3,1>,_Options> translation_;
+ protected:
+  Map<Sophus::SO3<Scalar> const, Options> const so3_;
+  Map<Sophus::Vector3<Scalar> const, Options> const translation_;
 };
-
-}
+}  // namespace Eigen
 
 #endif

--- a/thirdparty/sophus/sim2.hpp
+++ b/thirdparty/sophus/sim2.hpp
@@ -1,0 +1,727 @@
+/// @file
+/// Similarity group Sim(2) - scaling, rotation and translation in 2d.
+
+#ifndef SOPHUS_SIM2_HPP
+#define SOPHUS_SIM2_HPP
+
+#include "rxso2.hpp"
+#include "sim_details.hpp"
+
+namespace Sophus {
+template <class Scalar_, int Options = 0>
+class Sim2;
+using Sim2d = Sim2<double>;
+using Sim2f = Sim2<float>;
+}  // namespace Sophus
+
+namespace Eigen {
+namespace internal {
+
+template <class Scalar_, int Options>
+struct traits<Sophus::Sim2<Scalar_, Options>> {
+  using Scalar = Scalar_;
+  using TranslationType = Sophus::Vector2<Scalar, Options>;
+  using RxSO2Type = Sophus::RxSO2<Scalar, Options>;
+};
+
+template <class Scalar_, int Options>
+struct traits<Map<Sophus::Sim2<Scalar_>, Options>>
+    : traits<Sophus::Sim2<Scalar_, Options>> {
+  using Scalar = Scalar_;
+  using TranslationType = Map<Sophus::Vector2<Scalar>, Options>;
+  using RxSO2Type = Map<Sophus::RxSO2<Scalar>, Options>;
+};
+
+template <class Scalar_, int Options>
+struct traits<Map<Sophus::Sim2<Scalar_> const, Options>>
+    : traits<Sophus::Sim2<Scalar_, Options> const> {
+  using Scalar = Scalar_;
+  using TranslationType = Map<Sophus::Vector2<Scalar> const, Options>;
+  using RxSO2Type = Map<Sophus::RxSO2<Scalar> const, Options>;
+};
+}  // namespace internal
+}  // namespace Eigen
+
+namespace Sophus {
+
+/// Sim2 base type - implements Sim2 class but is storage agnostic.
+///
+/// Sim(2) is the group of rotations  and translation and scaling in 2d. It is
+/// the semi-direct product of R+xSO(2) and the 2d Euclidean vector space. The
+/// class is represented using a composition of RxSO2  for scaling plus
+/// rotation and a 2-vector for translation.
+///
+/// Sim(2) is neither compact, nor a commutative group.
+///
+/// See RxSO2 for more details of the scaling + rotation representation in 2d.
+///
+template <class Derived>
+class Sim2Base {
+ public:
+  using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
+  using TranslationType =
+      typename Eigen::internal::traits<Derived>::TranslationType;
+  using RxSO2Type = typename Eigen::internal::traits<Derived>::RxSO2Type;
+
+  /// Degrees of freedom of manifold, number of dimensions in tangent space
+  /// (two for translation, one for rotation and one for scaling).
+  static int constexpr DoF = 4;
+  /// Number of internal parameters used (2-tuple for complex number, two for
+  /// translation).
+  static int constexpr num_parameters = 4;
+  /// Group transformations are 3x3 matrices.
+  static int constexpr N = 3;
+  using Transformation = Matrix<Scalar, N, N>;
+  using Point = Vector2<Scalar>;
+  using HomogeneousPoint = Vector3<Scalar>;
+  using Line = ParametrizedLine2<Scalar>;
+  using Tangent = Vector<Scalar, DoF>;
+  using Adjoint = Matrix<Scalar, DoF, DoF>;
+
+  /// For binary operations the return type is determined with the
+  /// ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  /// types, as well as other compatible scalar types such as Ceres::Jet and
+  /// double scalars with SIM2 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
+
+  template <typename OtherDerived>
+  using Sim2Product = Sim2<ReturnScalar<OtherDerived>>;
+
+  template <typename PointDerived>
+  using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector3<ReturnScalar<HPointDerived>>;
+
+  /// Adjoint transformation
+  ///
+  /// This function return the adjoint transformation ``Ad`` of the group
+  /// element ``A`` such that for all ``x`` it holds that
+  /// ``hat(Ad_A * x) = A * hat(x) A^{-1}``. See hat-operator below.
+  ///
+  SOPHUS_FUNC Adjoint Adj() const {
+    Adjoint res;
+    res.setZero();
+    res.template block<2, 2>(0, 0) = rxso2().matrix();
+    res(0, 2) = translation()[1];
+    res(1, 2) = -translation()[0];
+    res.template block<2, 1>(0, 3) = -translation();
+
+    res(2, 2) = Scalar(1);
+
+    res(3, 3) = Scalar(1);
+    return res;
+  }
+
+  /// Returns copy of instance casted to NewScalarType.
+  ///
+  template <class NewScalarType>
+  SOPHUS_FUNC Sim2<NewScalarType> cast() const {
+    return Sim2<NewScalarType>(rxso2().template cast<NewScalarType>(),
+                               translation().template cast<NewScalarType>());
+  }
+
+  /// Returns group inverse.
+  ///
+  SOPHUS_FUNC Sim2<Scalar> inverse() const {
+    RxSO2<Scalar> invR = rxso2().inverse();
+    return Sim2<Scalar>(invR, invR * (translation() * Scalar(-1)));
+  }
+
+  /// Logarithmic map
+  ///
+  /// Computes the logarithm, the inverse of the group exponential which maps
+  /// element of the group (rigid body transformations) to elements of the
+  /// tangent space (twist).
+  ///
+  /// To be specific, this function computes ``vee(logmat(.))`` with
+  /// ``logmat(.)`` being the matrix logarithm and ``vee(.)`` the vee-operator
+  /// of Sim(2).
+  ///
+  SOPHUS_FUNC Tangent log() const {
+    /// The derivation of the closed-form Sim(2) logarithm for is done
+    /// analogously to the closed-form solution of the SE(2) logarithm, see
+    /// J. Gallier, D. Xu, "Computing exponentials of skew symmetric matrices
+    /// and logarithms of orthogonal matrices", IJRA 2002.
+    /// https:///pdfs.semanticscholar.org/cfe3/e4b39de63c8cabd89bf3feff7f5449fc981d.pdf
+    /// (Sec. 6., pp. 8)
+    Tangent res;
+    Vector2<Scalar> const theta_sigma = rxso2().log();
+    Scalar const theta = theta_sigma[0];
+    Scalar const sigma = theta_sigma[1];
+    Matrix2<Scalar> const Omega = SO2<Scalar>::hat(theta);
+    Matrix2<Scalar> const W_inv =
+        details::calcWInv<Scalar, 2>(Omega, theta, sigma, scale());
+
+    res.segment(0, 2) = W_inv * translation();
+    res[2] = theta;
+    res[3] = sigma;
+    return res;
+  }
+
+  /// Returns 3x3 matrix representation of the instance.
+  ///
+  /// It has the following form:
+  ///
+  ///   | s*R t |
+  ///   |  o  1 |
+  ///
+  /// where ``R`` is a 2x2 rotation matrix, ``s`` a scale factor, ``t`` a
+  /// translation 2-vector and ``o`` a 2-column vector of zeros.
+  ///
+  SOPHUS_FUNC Transformation matrix() const {
+    Transformation homogenious_matrix;
+    homogenious_matrix.template topLeftCorner<2, 3>() = matrix2x3();
+    homogenious_matrix.row(2) =
+        Matrix<Scalar, 3, 1>(Scalar(0), Scalar(0), Scalar(1));
+    return homogenious_matrix;
+  }
+
+  /// Returns the significant first two rows of the matrix above.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, 2, 3> matrix2x3() const {
+    Matrix<Scalar, 2, 3> matrix;
+    matrix.template topLeftCorner<2, 2>() = rxso2().matrix();
+    matrix.col(2) = translation();
+    return matrix;
+  }
+
+  /// Assignment operator.
+  ///
+  SOPHUS_FUNC Sim2Base& operator=(Sim2Base const& other) = default;
+
+  /// Assignment-like operator from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC Sim2Base<Derived>& operator=(
+      Sim2Base<OtherDerived> const& other) {
+    rxso2() = other.rxso2();
+    translation() = other.translation();
+    return *this;
+  }
+
+  /// Group multiplication, which is rotation plus scaling concatenation.
+  ///
+  /// Note: That scaling is calculated with saturation. See RxSO2 for
+  /// details.
+  ///
+  template <typename OtherDerived>
+  SOPHUS_FUNC Sim2Product<OtherDerived> operator*(
+      Sim2Base<OtherDerived> const& other) const {
+    return Sim2Product<OtherDerived>(
+        rxso2() * other.rxso2(), translation() + rxso2() * other.translation());
+  }
+
+  /// Group action on 2-points.
+  ///
+  /// This function rotates, scales and translates a two dimensional point
+  /// ``p`` by the Sim(2) element ``(bar_sR_foo, t_bar)`` (= similarity
+  /// transformation):
+  ///
+  ///   ``p_bar = bar_sR_foo * p_foo + t_bar``.
+  ///
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 2>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
+    return rxso2() * p + translation();
+  }
+
+  /// Group action on homogeneous 2-points. See above for more details.
+  ///
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 3>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const PointProduct<HPointDerived> tp =
+        rxso2() * p.template head<2>() + p(2) * translation();
+    return HomogeneousPointProduct<HPointDerived>(tp(0), tp(1), p(2));
+  }
+
+  /// Group action on lines.
+  ///
+  /// This function rotates, scales and translates a parametrized line
+  /// ``l(t) = o + t * d`` by the Sim(2) element:
+  ///
+  /// Origin ``o`` is rotated, scaled and translated
+  /// Direction ``d`` is rotated
+  ///
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    Line rotatedLine = rxso2() * l;
+    return Line(rotatedLine.origin() + translation(), rotatedLine.direction());
+  }
+
+  /// Returns internal parameters of Sim(2).
+  ///
+  /// It returns (c[0], c[1], t[0], t[1]),
+  /// with c being the complex number, t the translation 3-vector.
+  ///
+  SOPHUS_FUNC Sophus::Vector<Scalar, num_parameters> params() const {
+    Sophus::Vector<Scalar, num_parameters> p;
+    p << rxso2().params(), translation();
+    return p;
+  }
+
+  /// In-place group multiplication. This method is only valid if the return
+  /// type of the multiplication is compatible with this SO2's Scalar type.
+  ///
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC Sim2Base<Derived>& operator*=(
+      Sim2Base<OtherDerived> const& other) {
+    *static_cast<Derived*>(this) = *this * other;
+    return *this;
+  }
+
+  /// Setter of non-zero complex number.
+  ///
+  /// Precondition: ``z`` must not be close to zero.
+  ///
+  SOPHUS_FUNC void setComplex(Vector2<Scalar> const& z) {
+    rxso2().setComplex(z);
+  }
+
+  /// Accessor of complex number.
+  ///
+  SOPHUS_FUNC
+  typename Eigen::internal::traits<Derived>::RxSO2Type::ComplexType const&
+  complex() const {
+    return rxso2().complex();
+  }
+
+  /// Returns Rotation matrix
+  ///
+  SOPHUS_FUNC Matrix2<Scalar> rotationMatrix() const {
+    return rxso2().rotationMatrix();
+  }
+
+  /// Mutator of SO2 group.
+  ///
+  SOPHUS_FUNC RxSO2Type& rxso2() {
+    return static_cast<Derived*>(this)->rxso2();
+  }
+
+  /// Accessor of SO2 group.
+  ///
+  SOPHUS_FUNC RxSO2Type const& rxso2() const {
+    return static_cast<Derived const*>(this)->rxso2();
+  }
+
+  /// Returns scale.
+  ///
+  SOPHUS_FUNC Scalar scale() const { return rxso2().scale(); }
+
+  /// Setter of complex number using rotation matrix ``R``, leaves scale as is.
+  ///
+  SOPHUS_FUNC void setRotationMatrix(Matrix2<Scalar>& R) {
+    rxso2().setRotationMatrix(R);
+  }
+
+  /// Sets scale and leaves rotation as is.
+  ///
+  /// Note: This function as a significant computational cost, since it has to
+  /// call the square root twice.
+  ///
+  SOPHUS_FUNC void setScale(Scalar const& scale) { rxso2().setScale(scale); }
+
+  /// Setter of complexnumber using scaled rotation matrix ``sR``.
+  ///
+  /// Precondition: The 2x2 matrix must be "scaled orthogonal"
+  ///               and have a positive determinant.
+  ///
+  SOPHUS_FUNC void setScaledRotationMatrix(Matrix2<Scalar> const& sR) {
+    rxso2().setScaledRotationMatrix(sR);
+  }
+
+  /// Mutator of translation vector
+  ///
+  SOPHUS_FUNC TranslationType& translation() {
+    return static_cast<Derived*>(this)->translation();
+  }
+
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC TranslationType const& translation() const {
+    return static_cast<Derived const*>(this)->translation();
+  }
+};
+
+/// Sim2 using default storage; derived from Sim2Base.
+template <class Scalar_, int Options>
+class Sim2 : public Sim2Base<Sim2<Scalar_, Options>> {
+ public:
+  using Base = Sim2Base<Sim2<Scalar_, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+  using RxSo2Member = RxSO2<Scalar, Options>;
+  using TranslationMember = Vector2<Scalar, Options>;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// Default constructor initializes similarity transform to the identity.
+  ///
+  SOPHUS_FUNC Sim2();
+
+  /// Copy constructor
+  ///
+  SOPHUS_FUNC Sim2(Sim2 const& other) = default;
+
+  /// Copy-like constructor from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC Sim2(Sim2Base<OtherDerived> const& other)
+      : rxso2_(other.rxso2()), translation_(other.translation()) {
+    static_assert(std::is_same<typename OtherDerived::Scalar, Scalar>::value,
+                  "must be same Scalar type");
+  }
+
+  /// Constructor from RxSO2 and translation vector
+  ///
+  template <class OtherDerived, class D>
+  SOPHUS_FUNC Sim2(RxSO2Base<OtherDerived> const& rxso2,
+                   Eigen::MatrixBase<D> const& translation)
+      : rxso2_(rxso2), translation_(translation) {
+    static_assert(std::is_same<typename OtherDerived::Scalar, Scalar>::value,
+                  "must be same Scalar type");
+    static_assert(std::is_same<typename D::Scalar, Scalar>::value,
+                  "must be same Scalar type");
+  }
+
+  /// Constructor from complex number and translation vector.
+  ///
+  /// Precondition: complex number must not be close to zero.
+  ///
+  template <class D>
+  SOPHUS_FUNC Sim2(Vector2<Scalar> const& complex_number,
+                   Eigen::MatrixBase<D> const& translation)
+      : rxso2_(complex_number), translation_(translation) {
+    static_assert(std::is_same<typename D::Scalar, Scalar>::value,
+                  "must be same Scalar type");
+  }
+
+  /// Constructor from 3x3 matrix
+  ///
+  /// Precondition: Top-left 2x2 matrix needs to be "scaled-orthogonal" with
+  ///               positive determinant. The last row must be ``(0, 0, 1)``.
+  ///
+  SOPHUS_FUNC explicit Sim2(Matrix<Scalar, 3, 3> const& T)
+      : rxso2_((T.template topLeftCorner<2, 2>()).eval()),
+        translation_(T.template block<2, 1>(0, 2)) {}
+
+  /// This provides unsafe read/write access to internal data. Sim(2) is
+  /// represented by a complex number (two parameters) and a 2-vector. When
+  /// using direct write access, the user needs to take care of that the
+  /// complex number is not set close to zero.
+  ///
+  SOPHUS_FUNC Scalar* data() {
+    // rxso2_ and translation_ are laid out sequentially with no padding
+    return rxso2_.data();
+  }
+
+  /// Const version of data() above.
+  ///
+  SOPHUS_FUNC Scalar const* data() const {
+    // rxso2_ and translation_ are laid out sequentially with no padding
+    return rxso2_.data();
+  }
+
+  /// Accessor of RxSO2
+  ///
+  SOPHUS_FUNC RxSo2Member& rxso2() { return rxso2_; }
+
+  /// Mutator of RxSO2
+  ///
+  SOPHUS_FUNC RxSo2Member const& rxso2() const { return rxso2_; }
+
+  /// Mutator of translation vector
+  ///
+  SOPHUS_FUNC TranslationMember& translation() { return translation_; }
+
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC TranslationMember const& translation() const {
+    return translation_;
+  }
+
+  /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.
+  ///
+  SOPHUS_FUNC static Transformation Dxi_exp_x_matrix_at_0(int i) {
+    return generator(i);
+  }
+
+  /// Derivative of Lie bracket with respect to first element.
+  ///
+  /// This function returns ``D_a [a, b]`` with ``D_a`` being the
+  /// differential operator with respect to ``a``, ``[a, b]`` being the lie
+  /// bracket of the Lie algebra sim(2).
+  /// See ``lieBracket()`` below.
+  ///
+
+  /// Group exponential
+  ///
+  /// This functions takes in an element of tangent space and returns the
+  /// corresponding element of the group Sim(2).
+  ///
+  /// The first two components of ``a`` represent the translational part
+  /// ``upsilon`` in the tangent space of Sim(2), the following two components
+  /// of ``a`` represents the rotation ``theta`` and the final component
+  /// represents the logarithm of the scaling factor ``sigma``.
+  /// To be more specific, this function computes ``expmat(hat(a))`` with
+  /// ``expmat(.)`` being the matrix exponential and ``hat(.)`` the hat-operator
+  /// of Sim(2), see below.
+  ///
+  SOPHUS_FUNC static Sim2<Scalar> exp(Tangent const& a) {
+    // For the derivation of the exponential map of Sim(N) see
+    // H. Strasdat, "Local Accuracy and Global Consistency for Efficient Visual
+    // SLAM", PhD thesis, 2012.
+    // http:///hauke.strasdat.net/files/strasdat_thesis_2012.pdf (A.5, pp. 186)
+    Vector2<Scalar> const upsilon = a.segment(0, 2);
+    Scalar const theta = a[2];
+    Scalar const sigma = a[3];
+    RxSO2<Scalar> rxso2 = RxSO2<Scalar>::exp(a.template tail<2>());
+    Matrix2<Scalar> const Omega = SO2<Scalar>::hat(theta);
+    Matrix2<Scalar> const W = details::calcW<Scalar, 2>(Omega, theta, sigma);
+    return Sim2<Scalar>(rxso2, W * upsilon);
+  }
+
+  /// Returns the ith infinitesimal generators of Sim(2).
+  ///
+  /// The infinitesimal generators of Sim(2) are:
+  ///
+  /// ```
+  ///         |  0  0  1 |
+  ///   G_0 = |  0  0  0 |
+  ///         |  0  0  0 |
+  ///
+  ///         |  0  0  0 |
+  ///   G_1 = |  0  0  1 |
+  ///         |  0  0  0 |
+  ///
+  ///         |  0 -1  0 |
+  ///   G_2 = |  1  0  0 |
+  ///         |  0  0  0 |
+  ///
+  ///         |  1  0  0 |
+  ///   G_3 = |  0  1  0 |
+  ///         |  0  0  0 |
+  /// ```
+  ///
+  /// Precondition: ``i`` must be in [0, 3].
+  ///
+  SOPHUS_FUNC static Transformation generator(int i) {
+    SOPHUS_ENSURE(i >= 0 || i <= 3, "i should be in range [0,3].");
+    Tangent e;
+    e.setZero();
+    e[i] = Scalar(1);
+    return hat(e);
+  }
+
+  /// hat-operator
+  ///
+  /// It takes in the 4-vector representation and returns the corresponding
+  /// matrix representation of Lie algebra element.
+  ///
+  /// Formally, the hat()-operator of Sim(2) is defined as
+  ///
+  ///   ``hat(.): R^4 -> R^{3x3},  hat(a) = sum_i a_i * G_i``  (for i=0,...,6)
+  ///
+  /// with ``G_i`` being the ith infinitesimal generator of Sim(2).
+  ///
+  /// The corresponding inverse is the vee()-operator, see below.
+  ///
+  SOPHUS_FUNC static Transformation hat(Tangent const& a) {
+    Transformation Omega;
+    Omega.template topLeftCorner<2, 2>() =
+        RxSO2<Scalar>::hat(a.template tail<2>());
+    Omega.col(2).template head<2>() = a.template head<2>();
+    Omega.row(2).setZero();
+    return Omega;
+  }
+
+  /// Lie bracket
+  ///
+  /// It computes the Lie bracket of Sim(2). To be more specific, it computes
+  ///
+  ///   ``[omega_1, omega_2]_sim2 := vee([hat(omega_1), hat(omega_2)])``
+  ///
+  /// with ``[A,B] := AB-BA`` being the matrix commutator, ``hat(.)`` the
+  /// hat()-operator and ``vee(.)`` the vee()-operator of Sim(2).
+  ///
+  SOPHUS_FUNC static Tangent lieBracket(Tangent const& a, Tangent const& b) {
+    Vector2<Scalar> const upsilon1 = a.template head<2>();
+    Vector2<Scalar> const upsilon2 = b.template head<2>();
+    Scalar const theta1 = a[2];
+    Scalar const theta2 = b[2];
+    Scalar const sigma1 = a[3];
+    Scalar const sigma2 = b[3];
+
+    Tangent res;
+    res[0] = -theta1 * upsilon2[1] + theta2 * upsilon1[1] +
+             sigma1 * upsilon2[0] - sigma2 * upsilon1[0];
+    res[1] = theta1 * upsilon2[0] - theta2 * upsilon1[0] +
+             sigma1 * upsilon2[1] - sigma2 * upsilon1[1];
+    res[2] = Scalar(0);
+    res[3] = Scalar(0);
+
+    return res;
+  }
+
+  /// Draw uniform sample from Sim(2) manifold.
+  ///
+  /// Translations are drawn component-wise from the range [-1, 1].
+  /// The scale factor is drawn uniformly in log2-space from [-1, 1],
+  /// hence the scale is in [0.5, 2].
+  ///
+  template <class UniformRandomBitGenerator>
+  static Sim2 sampleUniform(UniformRandomBitGenerator& generator) {
+    std::uniform_real_distribution<Scalar> uniform(Scalar(-1), Scalar(1));
+    return Sim2(RxSO2<Scalar>::sampleUniform(generator),
+                Vector2<Scalar>(uniform(generator), uniform(generator)));
+  }
+
+  /// vee-operator
+  ///
+  /// It takes the 3x3-matrix representation ``Omega`` and maps it to the
+  /// corresponding 4-vector representation of Lie algebra.
+  ///
+  /// This is the inverse of the hat()-operator, see above.
+  ///
+  /// Precondition: ``Omega`` must have the following structure:
+  ///
+  ///                |  d -c  a |
+  ///                |  c  d  b |
+  ///                |  0  0  0 |
+  ///
+  SOPHUS_FUNC static Tangent vee(Transformation const& Omega) {
+    Tangent upsilon_omega_sigma;
+    upsilon_omega_sigma.template head<2>() = Omega.col(2).template head<2>();
+    upsilon_omega_sigma.template tail<2>() =
+        RxSO2<Scalar>::vee(Omega.template topLeftCorner<2, 2>());
+    return upsilon_omega_sigma;
+  }
+
+ protected:
+  RxSo2Member rxso2_;
+  TranslationMember translation_;
+};
+
+template <class Scalar, int Options>
+Sim2<Scalar, Options>::Sim2() : translation_(TranslationMember::Zero()) {
+  static_assert(std::is_standard_layout<Sim2>::value,
+                "Assume standard layout for the use of offsetof check below.");
+  static_assert(
+      offsetof(Sim2, rxso2_) + sizeof(Scalar) * RxSO2<Scalar>::num_parameters ==
+          offsetof(Sim2, translation_),
+      "This class assumes packed storage and hence will only work "
+      "correctly depending on the compiler (options) - in "
+      "particular when using [this->data(), this-data() + "
+      "num_parameters] to access the raw data in a contiguous fashion.");
+}
+
+}  // namespace Sophus
+
+namespace Eigen {
+
+/// Specialization of Eigen::Map for ``Sim2``; derived from Sim2Base.
+///
+/// Allows us to wrap Sim2 objects around POD array.
+template <class Scalar_, int Options>
+class Map<Sophus::Sim2<Scalar_>, Options>
+    : public Sophus::Sim2Base<Map<Sophus::Sim2<Scalar_>, Options>> {
+ public:
+  using Base = Sophus::Sim2Base<Map<Sophus::Sim2<Scalar_>, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+
+  // LCOV_EXCL_START
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  // LCOV_EXCL_STOP
+
+  using Base::operator*=;
+  using Base::operator*;
+
+  SOPHUS_FUNC Map(Scalar* coeffs)
+      : rxso2_(coeffs),
+        translation_(coeffs + Sophus::RxSO2<Scalar>::num_parameters) {}
+
+  /// Mutator of RxSO2
+  ///
+  SOPHUS_FUNC Map<Sophus::RxSO2<Scalar>, Options>& rxso2() { return rxso2_; }
+
+  /// Accessor of RxSO2
+  ///
+  SOPHUS_FUNC Map<Sophus::RxSO2<Scalar>, Options> const& rxso2() const {
+    return rxso2_;
+  }
+
+  /// Mutator of translation vector
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector2<Scalar>, Options>& translation() {
+    return translation_;
+  }
+
+  /// Accessor of translation vector
+  SOPHUS_FUNC Map<Sophus::Vector2<Scalar>, Options> const& translation() const {
+    return translation_;
+  }
+
+ protected:
+  Map<Sophus::RxSO2<Scalar>, Options> rxso2_;
+  Map<Sophus::Vector2<Scalar>, Options> translation_;
+};
+
+/// Specialization of Eigen::Map for ``Sim2 const``; derived from Sim2Base.
+///
+/// Allows us to wrap RxSO2 objects around POD array.
+template <class Scalar_, int Options>
+class Map<Sophus::Sim2<Scalar_> const, Options>
+    : public Sophus::Sim2Base<Map<Sophus::Sim2<Scalar_> const, Options>> {
+ public:
+  using Base = Sophus::Sim2Base<Map<Sophus::Sim2<Scalar_> const, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+
+  using Base::operator*=;
+  using Base::operator*;
+
+  SOPHUS_FUNC Map(Scalar const* coeffs)
+      : rxso2_(coeffs),
+        translation_(coeffs + Sophus::RxSO2<Scalar>::num_parameters) {}
+
+  /// Accessor of RxSO2
+  ///
+  SOPHUS_FUNC Map<Sophus::RxSO2<Scalar> const, Options> const& rxso2() const {
+    return rxso2_;
+  }
+
+  /// Accessor of translation vector
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector2<Scalar> const, Options> const& translation()
+      const {
+    return translation_;
+  }
+
+ protected:
+  Map<Sophus::RxSO2<Scalar> const, Options> const rxso2_;
+  Map<Sophus::Vector2<Scalar> const, Options> const translation_;
+};
+}  // namespace Eigen
+
+#endif

--- a/thirdparty/sophus/sim_details.hpp
+++ b/thirdparty/sophus/sim_details.hpp
@@ -1,0 +1,103 @@
+#ifndef SOPHUS_SIM_DETAILS_HPP
+#define SOPHUS_SIM_DETAILS_HPP
+
+#include "types.hpp"
+
+namespace Sophus {
+namespace details {
+
+template <class Scalar, int N>
+Matrix<Scalar, N, N> calcW(Matrix<Scalar, N, N> const& Omega,
+                           Scalar const theta, Scalar const sigma) {
+  using std::abs;
+  using std::cos;
+  using std::exp;
+  using std::sin;
+  static Matrix<Scalar, N, N> const I = Matrix<Scalar, N, N>::Identity();
+  static Scalar const one(1);
+  static Scalar const half(0.5);
+  Matrix<Scalar, N, N> const Omega2 = Omega * Omega;
+  Scalar const scale = exp(sigma);
+  Scalar A, B, C;
+  if (abs(sigma) < Constants<Scalar>::epsilon()) {
+    C = one;
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      A = half;
+      B = Scalar(1. / 6.);
+    } else {
+      Scalar theta_sq = theta * theta;
+      A = (one - cos(theta)) / theta_sq;
+      B = (theta - sin(theta)) / (theta_sq * theta);
+    }
+  } else {
+    C = (scale - one) / sigma;
+    if (abs(theta) < Constants<Scalar>::epsilon()) {
+      Scalar sigma_sq = sigma * sigma;
+      A = ((sigma - one) * scale + one) / sigma_sq;
+      B = (scale * half * sigma_sq + scale - one - sigma * scale) /
+          (sigma_sq * sigma);
+    } else {
+      Scalar theta_sq = theta * theta;
+      Scalar a = scale * sin(theta);
+      Scalar b = scale * cos(theta);
+      Scalar c = theta_sq + sigma * sigma;
+      A = (a * sigma + (one - b) * theta) / (theta * c);
+      B = (C - ((b - one) * sigma + a * theta) / (c)) * one / (theta_sq);
+    }
+  }
+  return A * Omega + B * Omega2 + C * I;
+}
+
+template <class Scalar, int N>
+Matrix<Scalar, N, N> calcWInv(Matrix<Scalar, N, N> const& Omega,
+                              Scalar const theta, Scalar const sigma,
+                              Scalar const scale) {
+  using std::abs;
+  using std::cos;
+  using std::sin;
+  static Matrix<Scalar, N, N> const I = Matrix<Scalar, N, N>::Identity();
+  static Scalar const half(0.5);
+  static Scalar const one(1);
+  static Scalar const two(2);
+  Matrix<Scalar, N, N> const Omega2 = Omega * Omega;
+  Scalar const scale_sq = scale * scale;
+  Scalar const theta_sq = theta * theta;
+  Scalar const sin_theta = sin(theta);
+  Scalar const cos_theta = cos(theta);
+
+  Scalar a, b, c;
+  if (abs(sigma * sigma) < Constants<Scalar>::epsilon()) {
+    c = one - half * sigma;
+    a = -half;
+    if (abs(theta_sq) < Constants<Scalar>::epsilon()) {
+      b = Scalar(1. / 12.);
+    } else {
+      b = (theta * sin_theta + two * cos_theta - two) /
+          (two * theta_sq * (cos_theta - one));
+    }
+  } else {
+    Scalar const scale_cu = scale_sq * scale;
+    c = sigma / (scale - one);
+    if (abs(theta_sq) < Constants<Scalar>::epsilon()) {
+      a = (-sigma * scale + scale - one) / ((scale - one) * (scale - one));
+      b = (scale_sq * sigma - two * scale_sq + scale * sigma + two * scale) /
+          (two * scale_cu - Scalar(6) * scale_sq + Scalar(6) * scale - two);
+    } else {
+      Scalar const s_sin_theta = scale * sin_theta;
+      Scalar const s_cos_theta = scale * cos_theta;
+      a = (theta * s_cos_theta - theta - sigma * s_sin_theta) /
+          (theta * (scale_sq - two * s_cos_theta + one));
+      b = -scale *
+          (theta * s_sin_theta - theta * sin_theta + sigma * s_cos_theta -
+           scale * sigma + sigma * cos_theta - sigma) /
+          (theta_sq * (scale_cu - two * scale * s_cos_theta - scale_sq +
+                       two * s_cos_theta + scale - one));
+    }
+  }
+  return a * Omega + b * Omega2 + c * I;
+}
+
+}  // namespace details
+}  // namespace Sophus
+
+#endif

--- a/thirdparty/sophus/so2.hpp
+++ b/thirdparty/sophus/so2.hpp
@@ -1,701 +1,626 @@
-// This file is part of Sophus.
-//
-// Copyright 2012-2013 Hauke Strasdat
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal in the Software without restriction, including without limitation the
-// rights  to use, copy, modify, merge, publish, distribute, sublicense, and/or
-// sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
+/// @file
+/// Special orthogonal group SO(2) - rotation in 2d.
 
 #ifndef SOPHUS_SO2_HPP
 #define SOPHUS_SO2_HPP
 
 #include <complex>
+#include <type_traits>
 
-#include "sophus.hpp"
+// Include only the selective set of Eigen headers that we need.
+// This helps when using Sophus with unusual compilers, like nvcc.
+#include <Eigen/LU>
 
-////////////////////////////////////////////////////////////////////////////
-// Forward Declarations / typedefs
-////////////////////////////////////////////////////////////////////////////
+#include "rotation_matrix.hpp"
+#include "types.hpp"
 
 namespace Sophus {
-template<typename _Scalar, int _Options=0> class SO2Group;
-typedef SO2Group<double> SO2 EIGEN_DEPRECATED;
-typedef SO2Group<double> SO2d; /**< double precision SO2 */
-typedef SO2Group<float> SO2f;  /**< single precision SO2 */
-}
-
-////////////////////////////////////////////////////////////////////////////
-// Eigen Traits (For querying derived types in CRTP hierarchy)
-////////////////////////////////////////////////////////////////////////////
-
-////////////////////////////////////////////////////////////////////////////
-// Eigen Traits (For querying derived types in CRTP hierarchy)
-////////////////////////////////////////////////////////////////////////////
+template <class Scalar_, int Options = 0>
+class SO2;
+using SO2d = SO2<double>;
+using SO2f = SO2<float>;
+}  // namespace Sophus
 
 namespace Eigen {
 namespace internal {
 
-template<typename _Scalar, int _Options>
-struct traits<Sophus::SO2Group<_Scalar,_Options> > {
-  typedef _Scalar Scalar;
-  typedef Matrix<Scalar,2,1> ComplexType;
+template <class Scalar_, int Options_>
+struct traits<Sophus::SO2<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using ComplexType = Sophus::Vector2<Scalar, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<Sophus::SO2Group<_Scalar>, _Options> >
-    : traits<Sophus::SO2Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<Matrix<Scalar,2,1>,_Options> ComplexType;
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::SO2<Scalar_>, Options_>>
+    : traits<Sophus::SO2<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using ComplexType = Map<Sophus::Vector2<Scalar>, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<const Sophus::SO2Group<_Scalar>, _Options> >
-    : traits<const Sophus::SO2Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<const Matrix<Scalar,2,1>,_Options> ComplexType;
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::SO2<Scalar_> const, Options_>>
+    : traits<Sophus::SO2<Scalar_, Options_> const> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using ComplexType = Map<Sophus::Vector2<Scalar> const, Options>;
 };
-
-}
-}
+}  // namespace internal
+}  // namespace Eigen
 
 namespace Sophus {
-using namespace Eigen;
 
-/**
- * \brief SO2 base type - implements SO2 class but is storage agnostic
- *
- * [add more detailed description/tutorial]
- */
-template<typename Derived>
-class SO2GroupBase {
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
-  /** \brief complex number reference type */
-  typedef typename internal::traits<Derived>::ComplexType &
-  ComplexReference;
-  /** \brief complex number const reference type */
-  typedef const typename internal::traits<Derived>::ComplexType &
-  ConstComplexReference;
+/// SO2 base type - implements SO2 class but is storage agnostic.
+///
+/// SO(2) is the group of rotations in 2d. As a matrix group, it is the set of
+/// matrices which are orthogonal such that ``R * R' = I`` (with ``R'`` being
+/// the transpose of ``R``) and have a positive determinant. In particular, the
+/// determinant is 1. Let ``theta`` be the rotation angle, the rotation matrix
+/// can be written in close form:
+///
+///      | cos(theta) -sin(theta) |
+///      | sin(theta)  cos(theta) |
+///
+/// As a matter of fact, the first column of those matrices is isomorph to the
+/// set of unit complex numbers U(1). Thus, internally, SO2 is represented as
+/// complex number with length 1.
+///
+/// SO(2) is a compact and commutative group. First it is compact since the set
+/// of rotation matrices is a closed and bounded set. Second it is commutative
+/// since ``R(alpha) * R(beta) = R(beta) * R(alpha)``,  simply because ``alpha +
+/// beta = beta + alpha`` with ``alpha`` and ``beta`` being rotation angles
+/// (about the same axis).
+///
+/// Class invariant: The 2-norm of ``unit_complex`` must be close to 1.
+/// Technically speaking, it must hold that:
+///
+///   ``|unit_complex().squaredNorm() - 1| <= Constants::epsilon()``.
+template <class Derived>
+class SO2Base {
+ public:
+  static constexpr int Options = Eigen::internal::traits<Derived>::Options;
+  using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
+  using ComplexT = typename Eigen::internal::traits<Derived>::ComplexType;
+  using ComplexTemporaryType = Sophus::Vector2<Scalar, Options>;
 
-  /** \brief degree of freedom of group
-   *         (one for in-plane rotation) */
-  static const int DoF = 1;
-  /** \brief number of internal parameters used
-   *         (unit complex number for rotation) */
-  static const int num_parameters = 2;
-  /** \brief group transformations are NxN matrices */
-  static const int N = 2;
-  /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
-  /** \brief point type */
-  typedef Matrix<Scalar,2,1> Point;
-  /** \brief tangent vector type */
-  typedef Scalar Tangent;
-  /** \brief adjoint transformation type */
-  typedef Scalar Adjoint;
+  /// Degrees of freedom of manifold, number of dimensions in tangent space (one
+  /// since we only have in-plane rotations).
+  static int constexpr DoF = 1;
+  /// Number of internal parameters used (complex numbers are a tuples).
+  static int constexpr num_parameters = 2;
+  /// Group transformations are 2x2 matrices.
+  static int constexpr N = 2;
+  using Transformation = Matrix<Scalar, N, N>;
+  using Point = Vector2<Scalar>;
+  using HomogeneousPoint = Vector3<Scalar>;
+  using Line = ParametrizedLine2<Scalar>;
+  using Tangent = Scalar;
+  using Adjoint = Scalar;
 
-  /**
-   * \brief Adjoint transformation
-   *
-   * This function return the adjoint transformation \f$ Ad \f$ of the
-   * group instance \f$ A \f$  such that for all \f$ x \f$
-   * it holds that \f$ \widehat{Ad_A\cdot x} = A\widehat{x}A^{-1} \f$
-   * with \f$\ \widehat{\cdot} \f$ being the hat()-operator.
-   *
-   * For SO2, it simply returns 1.
-   */
-  inline
-  const Adjoint Adj() const {
-    return 1;
+  /// For binary operations the return type is determined with the
+  /// ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  /// types, as well as other compatible scalar types such as Ceres::Jet and
+  /// double scalars with SO2 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
+
+  template <typename OtherDerived>
+  using SO2Product = SO2<ReturnScalar<OtherDerived>>;
+
+  template <typename PointDerived>
+  using PointProduct = Vector2<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector3<ReturnScalar<HPointDerived>>;
+
+  /// Adjoint transformation
+  ///
+  /// This function return the adjoint transformation ``Ad`` of the group
+  /// element ``A`` such that for all ``x`` it holds that
+  /// ``hat(Ad_A * x) = A * hat(x) A^{-1}``. See hat-operator below.
+  ///
+  /// It simply ``1``, since ``SO(2)`` is a commutative group.
+  ///
+  SOPHUS_FUNC Adjoint Adj() const { return Scalar(1); }
+
+  /// Returns copy of instance casted to NewScalarType.
+  ///
+  template <class NewScalarType>
+  SOPHUS_FUNC SO2<NewScalarType> cast() const {
+    return SO2<NewScalarType>(unit_complex().template cast<NewScalarType>());
   }
 
-  /**
-   * \returns copy of instance casted to NewScalarType
-   */
-  template<typename NewScalarType>
-  inline SO2Group<NewScalarType> cast() const {
-    return SO2Group<NewScalarType>(unit_complex()
-                                   .template cast<NewScalarType>() );
+  /// This provides unsafe read/write access to internal data. SO(2) is
+  /// represented by a unit complex number (two parameters). When using direct
+  /// write access, the user needs to take care of that the complex number stays
+  /// normalized.
+  ///
+  SOPHUS_FUNC Scalar* data() { return unit_complex_nonconst().data(); }
+
+  /// Const version of data() above.
+  ///
+  SOPHUS_FUNC Scalar const* data() const { return unit_complex().data(); }
+
+  /// Returns group inverse.
+  ///
+  SOPHUS_FUNC SO2<Scalar> inverse() const {
+    return SO2<Scalar>(unit_complex().x(), -unit_complex().y());
   }
 
-  /**
-   * \returns pointer to internal data
-   *
-   * This provides unsafe read/write access to internal data. SO2 is represented
-   * by a complex number with unit length (two parameters). When using direct
-   * write access, the user needs to take care of that the complex number stays
-   * normalized.
-   *
-   * \see normalize()
-   */
-  inline Scalar* data() {
-    return unit_complex_nonconst().data();
+  /// Logarithmic map
+  ///
+  /// Computes the logarithm, the inverse of the group exponential which maps
+  /// element of the group (rotation matrices) to elements of the tangent space
+  /// (rotation angles).
+  ///
+  /// To be specific, this function computes ``vee(logmat(.))`` with
+  /// ``logmat(.)`` being the matrix logarithm and ``vee(.)`` the vee-operator
+  /// of SO(2).
+  ///
+  SOPHUS_FUNC Scalar log() const {
+    using std::atan2;
+    return atan2(unit_complex().y(), unit_complex().x());
   }
 
-  /**
-   * \returns const pointer to internal data
-   *
-   * Const version of data().
-   */
-  inline const Scalar* data() const {
-    return unit_complex().data();
-  }
-
-  /**
-   * \brief Fast group multiplication
-   *
-   * This method is a fast version of operator*=(), since it does not perform
-   * normalization. It is up to the user to call normalize() once in a while.
-   *
-   * \see operator*=()
-   */
-  inline
-  void fastMultiply(const SO2Group<Scalar>& other) {
-    Scalar lhs_real = unit_complex().x();
-    Scalar lhs_imag = unit_complex().y();
-    const Scalar & rhs_real = other.unit_complex().x();
-    const Scalar & rhs_imag = other.unit_complex().y();
-    // complex multiplication
-    unit_complex_nonconst().x() = lhs_real*rhs_real - lhs_imag*rhs_imag;
-    unit_complex_nonconst().y() = lhs_real*rhs_imag + lhs_imag*rhs_real;
-  }
-
-  /**
-   * \returns group inverse of instance
-   */
-  inline
-  const SO2Group<Scalar> inverse() const {
-    return SO2Group<Scalar>(unit_complex().x(), -unit_complex().y());
-  }
-
-  /**
-   * \brief Logarithmic map
-   *
-   * \returns tangent space representation (=rotation angle) of instance
-   *
-   * \see  log().
-   */
-  inline
-  const Scalar log() const {
-    return SO2Group<Scalar>::log(*this);
-  }
-
-  /**
-   * \brief Normalize complex number
-   *
-   * It re-normalizes complex number to unit length. This method only needs to
-   * be called in conjunction with fastMultiply() or data() write access.
-   */
-  inline
-  void normalize() {
-    Scalar length =
-        std::sqrt(unit_complex().x()*unit_complex().x()
-             + unit_complex().y()*unit_complex().y());
-    if(length < SophusConstants<Scalar>::epsilon()) {
-      throw SophusException("Complex number is (near) zero!");
-    }
+  /// It re-normalizes ``unit_complex`` to unit length.
+  ///
+  /// Note: Because of the class invariant, there is typically no need to call
+  /// this function directly.
+  ///
+  SOPHUS_FUNC void normalize() {
+    using std::sqrt;
+    Scalar length = sqrt(unit_complex().x() * unit_complex().x() +
+                         unit_complex().y() * unit_complex().y());
+    SOPHUS_ENSURE(length >= Constants<Scalar>::epsilon(),
+                  "Complex number should not be close to zero!");
     unit_complex_nonconst().x() /= length;
     unit_complex_nonconst().y() /= length;
   }
 
-  /**
-   * \returns 2x2 matrix representation of instance
-   *
-   * For SO2, the matrix representation is an orthogonal matrix R with det(R)=1,
-   * thus the so-called rotation matrix.
-   */
-  inline
-  const Transformation matrix() const {
-    const Scalar & real = unit_complex().x();
-    const Scalar & imag = unit_complex().y();
+  /// Returns 2x2 matrix representation of the instance.
+  ///
+  /// For SO(2), the matrix representation is an orthogonal matrix ``R`` with
+  /// ``det(R)=1``, thus the so-called "rotation matrix".
+  ///
+  SOPHUS_FUNC Transformation matrix() const {
+    Scalar const& real = unit_complex().x();
+    Scalar const& imag = unit_complex().y();
     Transformation R;
-    R << real, -imag
-        ,imag,  real;
+    // clang-format off
+    R <<
+      real, -imag,
+      imag,  real;
+    // clang-format on
     return R;
   }
 
-  /**
-   * \brief Assignment operator
-   */
-  template<typename OtherDerived> inline
-  SO2GroupBase<Derived>& operator=(const SO2GroupBase<OtherDerived> & other) {
+  /// Assignment operator
+  ///
+  SOPHUS_FUNC SO2Base& operator=(SO2Base const& other) = default;
+
+  /// Assignment-like operator from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC SO2Base<Derived>& operator=(SO2Base<OtherDerived> const& other) {
     unit_complex_nonconst() = other.unit_complex();
     return *this;
   }
 
-  /**
-   * \brief Group multiplication
-   * \see operator*=()
-   */
-  inline
-  const SO2Group<Scalar> operator*(const SO2Group<Scalar>& other) const {
-    SO2Group<Scalar> result(*this);
-    result *= other;
-    return result;
+  /// Group multiplication, which is rotation concatenation.
+  ///
+  template <typename OtherDerived>
+  SOPHUS_FUNC SO2Product<OtherDerived> operator*(
+      SO2Base<OtherDerived> const& other) const {
+    using ResultT = ReturnScalar<OtherDerived>;
+    Scalar const lhs_real = unit_complex().x();
+    Scalar const lhs_imag = unit_complex().y();
+    typename OtherDerived::Scalar const& rhs_real = other.unit_complex().x();
+    typename OtherDerived::Scalar const& rhs_imag = other.unit_complex().y();
+    // complex multiplication
+    ResultT const result_real = lhs_real * rhs_real - lhs_imag * rhs_imag;
+    ResultT const result_imag = lhs_real * rhs_imag + lhs_imag * rhs_real;
+
+    ResultT const squared_norm =
+        result_real * result_real + result_imag * result_imag;
+    // We can assume that the squared-norm is close to 1 since we deal with a
+    // unit complex number. Due to numerical precision issues, there might
+    // be a small drift after pose concatenation. Hence, we need to renormalizes
+    // the complex number here.
+    // Since squared-norm is close to 1, we do not need to calculate the costly
+    // square-root, but can use an approximation around 1 (see
+    // http://stackoverflow.com/a/12934750 for details).
+    if (squared_norm != ResultT(1.0)) {
+      ResultT const scale = ResultT(2.0) / (ResultT(1.0) + squared_norm);
+      return SO2Product<OtherDerived>(result_real * scale, result_imag * scale);
+    }
+    return SO2Product<OtherDerived>(result_real, result_imag);
   }
 
-  /**
-   * \brief Group action on \f$ \mathbf{R}^2 \f$
-   *
-   * \param p point \f$p \in \mathbf{R}^2 \f$
-   * \returns point \f$p' \in \mathbf{R}^2 \f$, rotated version of \f$p\f$
-   *
-   * This function rotates a point \f$ p \f$ in  \f$ \mathbf{R}^2 \f$ by the
-   * SO2 transformation \f$R\f$ (=rotation matrix): \f$ p' = R\cdot p \f$.
-   */
-  inline
-  const Point operator*(const Point & p) const {
-    const Scalar & real = unit_complex().x();
-    const Scalar & imag = unit_complex().y();
-    return Point(real*p[0] - imag*p[1], imag*p[0] + real*p[1]);
+  /// Group action on 2-points.
+  ///
+  /// This function rotates a 2 dimensional point ``p`` by the SO2 element
+  ///  ``bar_R_foo`` (= rotation matrix): ``p_bar = bar_R_foo * p_foo``.
+  ///
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 2>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
+    Scalar const& real = unit_complex().x();
+    Scalar const& imag = unit_complex().y();
+    return PointProduct<PointDerived>(real * p[0] - imag * p[1],
+                                      imag * p[0] + real * p[1]);
   }
 
-  /**
-   * \brief In-place group multiplication
-   *
-   * \see fastMultiply()
-   * \see operator*()
-   */
-  inline
-  void operator*=(const SO2Group<Scalar>& other) {
-    fastMultiply(other);
+  /// Group action on homogeneous 2-points.
+  ///
+  /// This function rotates a homogeneous 2 dimensional point ``p`` by the SO2
+  /// element ``bar_R_foo`` (= rotation matrix): ``p_bar = bar_R_foo * p_foo``.
+  ///
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 3>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    Scalar const& real = unit_complex().x();
+    Scalar const& imag = unit_complex().y();
+    return HomogeneousPointProduct<HPointDerived>(
+        real * p[0] - imag * p[1], imag * p[0] + real * p[1], p[2]);
+  }
+
+  /// Group action on lines.
+  ///
+  /// This function rotates a parametrized line ``l(t) = o + t * d`` by the SO2
+  /// element:
+  ///
+  /// Both direction ``d`` and origin ``o`` are rotated as a 2 dimensional point
+  ///
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), (*this) * l.direction());
+  }
+
+  /// In-place group multiplication. This method is only valid if the return
+  /// type of the multiplication is compatible with this SO2's Scalar type.
+  ///
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC SO2Base<Derived> operator*=(SO2Base<OtherDerived> const& other) {
+    *static_cast<Derived*>(this) = *this * other;
+    return *this;
+  }
+
+  /// Returns derivative of  this * SO2::exp(x)  wrt. x at x=0.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, num_parameters, DoF> Dx_this_mul_exp_x_at_0()
+      const {
+    return Matrix<Scalar, num_parameters, DoF>(-unit_complex()[1],
+                                               unit_complex()[0]);
+  }
+
+  /// Returns internal parameters of SO(2).
+  ///
+  /// It returns (c[0], c[1]), with c being the unit complex number.
+  ///
+  SOPHUS_FUNC Sophus::Vector<Scalar, num_parameters> params() const {
+    return unit_complex();
+  }
+
+  /// Takes in complex number / tuple and normalizes it.
+  ///
+  /// Precondition: The complex number must not be close to zero.
+  ///
+  SOPHUS_FUNC void setComplex(Point const& complex) {
+    unit_complex_nonconst() = complex;
     normalize();
   }
 
-  /**
-   * \brief Setter of internal unit complex number representation
-   *
-   * \param complex
-   * \pre   the complex number must not be near zero
-   *
-   * The complex number is normalized to unit length.
-   */
-  inline
-  void setComplex(const Point & complex) {
-    unit_complex() = complex;
-    normalize();
+  /// Accessor of unit quaternion.
+  ///
+  SOPHUS_FUNC
+  ComplexT const& unit_complex() const {
+    return static_cast<Derived const*>(this)->unit_complex();
   }
 
-  /**
-   * \brief Accessor of unit complex number
-   *
-   * No direct write access is given to ensure the complex stays normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstComplexReference unit_complex() const {
-    return static_cast<const Derived*>(this)->unit_complex();
-  }
-
-  ////////////////////////////////////////////////////////////////////////////
-  // public static functions
-  ////////////////////////////////////////////////////////////////////////////
-
-  /**
-   * \brief Group exponential
-   *
-   * \param theta tangent space element (=rotation angle \f$ \theta \f$)
-   * \returns     corresponding element of the group SO2
-   *
-   * To be more specific, this function computes \f$ \exp(\widehat{\theta}) \f$
-   * with \f$ \exp(\cdot) \f$ being the matrix exponential
-   * and \f$ \widehat{\cdot} \f$ the hat()-operator of SO2.
-   *
-   * \see hat()
-   * \see log()
-   */
-  inline static
-  const SO2Group<Scalar> exp(const Tangent & theta) {
-    return SO2Group<Scalar>(std::cos(theta), std::sin(theta));
-  }
-
-  /**
-   * \brief Generator
-   *
-   * The infinitesimal generator of SO2
-   * is \f$
-   *        G_0 = \left( \begin{array}{ccc}
-   *                          0& -1& \\
-   *                          1&  0&
-   *                     \end{array} \right).
-   * \f$
-   * \see hat()
-   */
-  inline static
-  const Transformation generator() {
-    return hat(1);
-  }
-
-  /**
-   * \brief hat-operator
-   *
-   * \param theta scalar representation of Lie algebra element
-   * \returns     2x2-matrix representatin of Lie algebra element
-   *
-   * Formally, the hat-operator of SO2 is defined
-   * as \f$ \widehat{\cdot}: \mathbf{R}^2 \rightarrow \mathbf{R}^{2\times 2},
-   * \quad \widehat{\theta} = G_0\cdot \theta \f$
-   * with \f$ G_0 \f$ being the infinitesial generator().
-   *
-   * \see generator()
-   * \see vee()
-   */
-  inline static
-  const Transformation hat(const Tangent & theta) {
-    Transformation Omega;
-    Omega <<  static_cast<Scalar>(0), -theta
-        ,  theta,     static_cast<Scalar>(0);
-    return Omega;
-  }
-
-  /**
-   * \brief Lie bracket
-   *
-   * \param theta1 scalar representation of Lie algebra element
-   * \param theta2 scalar representation of Lie algebra element
-   * \returns      zero
-   *
-   * It computes the bracket. For the Lie algebra so2, the Lie bracket is
-   * simply \f$ [\theta_1, \theta_2]_{so2} = 0 \f$ since SO2 is a
-   * commutative group.
-   *
-   * \see hat()
-   * \see vee()
-   */
-  inline static
-  const Tangent lieBracket(const Tangent & theta1,
-                           const Tangent & theta2) {
-    return static_cast<Scalar>(0);
-  }
-
-  /**
-   * \brief Logarithmic map
-   *
-   * \param other element of the group SO2
-   * \returns     corresponding tangent space element
-   *              (=rotation angle \f$ \theta \f$)
-   *
-   * Computes the logarithmic, the inverse of the group exponential.
-   * To be specific, this function computes \f$ \log({\cdot})^\vee \f$
-   * with \f$ \vee(\cdot) \f$ being the matrix logarithm
-   * and \f$ \vee{\cdot} \f$ the vee()-operator of SO2.
-   *
-   * \see exp()
-   * \see vee()
-   */
-  inline static
-  const Tangent log(const SO2Group<Scalar> & other) {
-    // todo: general implementation for Scalar not being float or double.
-    return atan2(other.unit_complex_.y(), other.unit_complex().x());
-  }
-
-  /**
-   * \brief vee-operator
-   *
-   * \param Omega 2x2-matrix representation of Lie algebra element
-   * \pre         Omega need to be a skew-symmetric matrix
-   * \returns     scalar representatin of Lie algebra element
-   *s
-   * This is the inverse of the hat()-operator.
-   *
-   * \see hat()
-   */
-  inline static
-  const Tangent vee(const Transformation & Omega) {
-    return static_cast<Scalar>(0.5)*(Omega(1,0) - Omega(0,1));
-  }
-
-private:
-  // Mutator of complex number is private so users are hampered
-  // from setting non-unit complex numbers.
-  EIGEN_STRONG_INLINE
-  ComplexReference unit_complex_nonconst() {
+ private:
+  /// Mutator of unit_complex is private to ensure class invariant. That is
+  /// the complex number must stay close to unit length.
+  ///
+  SOPHUS_FUNC
+  ComplexT& unit_complex_nonconst() {
     return static_cast<Derived*>(this)->unit_complex_nonconst();
   }
-
 };
 
-/**
- * \brief SO2 default type - Constructors and default storage for SO2 Type
- */
-template<typename _Scalar, int _Options>
-class SO2Group : public SO2GroupBase<SO2Group<_Scalar,_Options> > {
-  typedef SO2GroupBase<SO2Group<_Scalar,_Options> > Base;
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<SO2Group<_Scalar,_Options> >
-  ::Scalar Scalar;
-  /** \brief complex number reference type */
-  typedef typename internal::traits<SO2Group<_Scalar,_Options> >
-  ::ComplexType & ComplexReference;
-  /** \brief complex number const reference type */
-  typedef const typename internal::traits<SO2Group<_Scalar,_Options> >
-  ::ComplexType & ConstComplexReference;
+/// SO2 using  default storage; derived from SO2Base.
+template <class Scalar_, int Options>
+class SO2 : public SO2Base<SO2<Scalar_, Options>> {
+ public:
+  using Base = SO2Base<SO2<Scalar_, Options>>;
+  static int constexpr DoF = Base::DoF;
+  static int constexpr num_parameters = Base::num_parameters;
 
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+  using ComplexMember = Vector2<Scalar, Options>;
 
-  // base is friend so unit_complex_nonconst can be accessed from base
-  friend class SO2GroupBase<SO2Group<_Scalar,_Options> >;
+  /// ``Base`` is friend so unit_complex_nonconst can be accessed from ``Base``.
+  friend class SO2Base<SO2<Scalar, Options>>;
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  /**
-   * \brief Default constructor
-   *
-   * Initialize complex number to identity rotation.
-   */
-  inline SO2Group()
-    : unit_complex_(static_cast<Scalar>(1), static_cast<Scalar>(0)) {
+  /// Default constructor initializes unit complex number to identity rotation.
+  ///
+  SOPHUS_FUNC SO2() : unit_complex_(Scalar(1), Scalar(0)) {}
+
+  /// Copy constructor
+  ///
+  SOPHUS_FUNC SO2(SO2 const& other) = default;
+
+  /// Copy-like constructor from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC SO2(SO2Base<OtherDerived> const& other)
+      : unit_complex_(other.unit_complex()) {}
+
+  /// Constructor from rotation matrix
+  ///
+  /// Precondition: rotation matrix need to be orthogonal with determinant of 1.
+  ///
+  SOPHUS_FUNC explicit SO2(Transformation const& R)
+      : unit_complex_(Scalar(0.5) * (R(0, 0) + R(1, 1)),
+                      Scalar(0.5) * (R(1, 0) - R(0, 1))) {
+    SOPHUS_ENSURE(isOrthogonal(R), "R is not orthogonal:\n %", R);
+    SOPHUS_ENSURE(R.determinant() > Scalar(0), "det(R) is not positive: %",
+                  R.determinant());
   }
 
-  /**
-   * \brief Copy constructor
-   */
-  template<typename OtherDerived> inline
-  SO2Group(const SO2GroupBase<OtherDerived> & other)
-    : unit_complex_(other.unit_complex()) {
-  }
-
-  /**
-   * \brief Constructor from rotation matrix
-   *
-   * \pre rotation matrix need to be orthogonal with determinant of 1
-   */
-  inline explicit
-  SO2Group(const Transformation & R)
-    : unit_complex_(static_cast<Scalar>(0.5)*(R(0,0)+R(1,1)),
-                    static_cast<Scalar>(0.5)*(R(1,0)-R(0,1))) {
-    if (std::abs(R.determinant()-static_cast<Scalar>(1))
-        > SophusConstants<Scalar>::epsilon()) {
-      throw SophusException("det(R) is not near 1.");
-    }
-  }
-
-  /**
-   * \brief Constructor from pair of real and imaginary number
-   *
-   * \pre pair must not be zero
-   */
-  inline SO2Group(const Scalar & real, const Scalar & imag)
-    : unit_complex_(real, imag) {
+  /// Constructor from pair of real and imaginary number.
+  ///
+  /// Precondition: The pair must not be close to zero.
+  ///
+  SOPHUS_FUNC SO2(Scalar const& real, Scalar const& imag)
+      : unit_complex_(real, imag) {
     Base::normalize();
   }
 
-  /**
-   * \brief Constructor from 2-vector
-   *
-   * \pre vector must not be zero
-   */
-  inline explicit
-  SO2Group(const Matrix<Scalar,2,1> & complex)
-    : unit_complex_(complex) {
+  /// Constructor from 2-vector.
+  ///
+  /// Precondition: The vector must not be close to zero.
+  ///
+  template <class D>
+  SOPHUS_FUNC explicit SO2(Eigen::MatrixBase<D> const& complex)
+      : unit_complex_(complex) {
+    static_assert(std::is_same<typename D::Scalar, Scalar>::value,
+                  "must be same Scalar type");
     Base::normalize();
   }
 
-  /**
-   * \brief Constructor from std::complex
-   *
-   * \pre complex number must not be zero
-   */
-  inline explicit
-  SO2Group(const std::complex<Scalar> & complex)
-    : unit_complex_(complex.real(), complex.imag()) {
-    Base::normalize();
+  /// Constructor from an rotation angle.
+  ///
+  SOPHUS_FUNC explicit SO2(Scalar theta) {
+    unit_complex_nonconst() = SO2<Scalar>::exp(theta).unit_complex();
   }
 
-  /**
-   * \brief Constructor from an angle
-   */
-  inline explicit
-  SO2Group(Scalar theta) {
-    unit_complex_nonconst() = SO2Group<Scalar>::exp(theta).unit_complex();
-  }
-
-  /**
-   * \brief Accessor of unit complex number
-   *
-   * No direct write access is given to ensure the complex number stays
-   * normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstComplexReference unit_complex() const {
+  /// Accessor of unit complex number
+  ///
+  SOPHUS_FUNC ComplexMember const& unit_complex() const {
     return unit_complex_;
   }
 
-protected:
-  // Mutator of complex number is protected so users are hampered
-  // from setting non-unit complex numbers.
-  EIGEN_STRONG_INLINE
-  ComplexReference unit_complex_nonconst() {
-    return unit_complex_;
+  /// Group exponential
+  ///
+  /// This functions takes in an element of tangent space (= rotation angle
+  /// ``theta``) and returns the corresponding element of the group SO(2).
+  ///
+  /// To be more specific, this function computes ``expmat(hat(omega))``
+  /// with ``expmat(.)`` being the matrix exponential and ``hat(.)`` being the
+  /// hat()-operator of SO(2).
+  ///
+  SOPHUS_FUNC static SO2<Scalar> exp(Tangent const& theta) {
+    using std::cos;
+    using std::sin;
+    return SO2<Scalar>(cos(theta), sin(theta));
   }
 
-  static bool isNearZero(const Scalar & real, const Scalar & imag) {
-    return (real*real + imag*imag < SophusConstants<Scalar>::epsilon());
+  /// Returns derivative of exp(x) wrt. x.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
+      Tangent const& theta) {
+    using std::cos;
+    using std::sin;
+    return Sophus::Matrix<Scalar, num_parameters, DoF>(-sin(theta), cos(theta));
   }
 
-  Matrix<Scalar,2,1> unit_complex_;
+  /// Returns derivative of exp(x) wrt. x_i at x=0.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF>
+  Dx_exp_x_at_0() {
+    return Sophus::Matrix<Scalar, num_parameters, DoF>(Scalar(0), Scalar(1));
+  }
+
+  /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.
+  ///
+  SOPHUS_FUNC static Transformation Dxi_exp_x_matrix_at_0(int) {
+    return generator();
+  }
+
+  /// Returns the infinitesimal generators of SO(2).
+  ///
+  /// The infinitesimal generators of SO(2) is:
+  ///
+  ///     |  0  1 |
+  ///     | -1  0 |
+  ///
+  SOPHUS_FUNC static Transformation generator() { return hat(Scalar(1)); }
+
+  /// hat-operator
+  ///
+  /// It takes in the scalar representation ``theta`` (= rotation angle) and
+  /// returns the corresponding matrix representation of Lie algebra element.
+  ///
+  /// Formally, the hat()-operator of SO(2) is defined as
+  ///
+  ///   ``hat(.): R^2 -> R^{2x2},  hat(theta) = theta * G``
+  ///
+  /// with ``G`` being the infinitesimal generator of SO(2).
+  ///
+  /// The corresponding inverse is the vee()-operator, see below.
+  ///
+  SOPHUS_FUNC static Transformation hat(Tangent const& theta) {
+    Transformation Omega;
+    // clang-format off
+    Omega <<
+        Scalar(0),   -theta,
+            theta, Scalar(0);
+    // clang-format on
+    return Omega;
+  }
+
+  /// Returns closed SO2 given arbitrary 2x2 matrix.
+  ///
+  template <class S = Scalar>
+  static SOPHUS_FUNC enable_if_t<std::is_floating_point<S>::value, SO2>
+  fitToSO2(Transformation const& R) {
+    return SO2(makeRotationMatrix(R));
+  }
+
+  /// Lie bracket
+  ///
+  /// It returns the Lie bracket of SO(2). Since SO(2) is a commutative group,
+  /// the Lie bracket is simple ``0``.
+  ///
+  SOPHUS_FUNC static Tangent lieBracket(Tangent const&, Tangent const&) {
+    return Scalar(0);
+  }
+
+  /// Draw uniform sample from SO(2) manifold.
+  ///
+  template <class UniformRandomBitGenerator>
+  static SO2 sampleUniform(UniformRandomBitGenerator& generator) {
+    static_assert(IsUniformRandomBitGenerator<UniformRandomBitGenerator>::value,
+                  "generator must meet the UniformRandomBitGenerator concept");
+    std::uniform_real_distribution<Scalar> uniform(-Constants<Scalar>::pi(),
+                                                   Constants<Scalar>::pi());
+    return SO2(uniform(generator));
+  }
+
+  /// vee-operator
+  ///
+  /// It takes the 2x2-matrix representation ``Omega`` and maps it to the
+  /// corresponding scalar representation of Lie algebra.
+  ///
+  /// This is the inverse of the hat()-operator, see above.
+  ///
+  /// Precondition: ``Omega`` must have the following structure:
+  ///
+  ///                |  0 -a |
+  ///                |  a  0 |
+  ///
+  SOPHUS_FUNC static Tangent vee(Transformation const& Omega) {
+    using std::abs;
+    return Omega(1, 0);
+  }
+
+ protected:
+  /// Mutator of complex number is protected to ensure class invariant.
+  ///
+  SOPHUS_FUNC ComplexMember& unit_complex_nonconst() { return unit_complex_; }
+
+  ComplexMember unit_complex_;
 };
 
-} // end namespace
-
+}  // namespace Sophus
 
 namespace Eigen {
-/**
- * \brief Specialisation of Eigen::Map for SO2GroupBase
- *
- * Allows us to wrap SO2 Objects around POD array
- * (e.g. external c style complex number)
- */
-template<typename _Scalar, int _Options>
-class Map<Sophus::SO2Group<_Scalar>, _Options>
-    : public Sophus::SO2GroupBase<Map<Sophus::SO2Group<_Scalar>, _Options> > {
-  typedef Sophus::SO2GroupBase<Map<Sophus::SO2Group<_Scalar>, _Options> > Base;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief complex number reference type */
-  typedef typename internal::traits<Map>::ComplexType & ComplexReference;
-  /** \brief complex number const reference type */
-  typedef const typename internal::traits<Map>::ComplexType &
-  ConstComplexReference;
+/// Specialization of Eigen::Map for ``SO2``; derived from SO2Base.
+///
+/// Allows us to wrap SO2 objects around POD array (e.g. external c style
+/// complex number / tuple).
+template <class Scalar_, int Options>
+class Map<Sophus::SO2<Scalar_>, Options>
+    : public Sophus::SO2Base<Map<Sophus::SO2<Scalar_>, Options>> {
+ public:
+  using Base = Sophus::SO2Base<Map<Sophus::SO2<Scalar_>, Options>>;
+  using Scalar = Scalar_;
 
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-  // base is friend so unit_complex_nonconst can be accessed from base
-  friend class Sophus::SO2GroupBase<Map<Sophus::SO2Group<_Scalar>, _Options> >;
+  /// ``Base`` is friend so unit_complex_nonconst can be accessed from ``Base``.
+  friend class Sophus::SO2Base<Map<Sophus::SO2<Scalar_>, Options>>;
 
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
+  // LCOV_EXCL_START
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  // LCOV_EXCL_STOP
+
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(Scalar* coeffs) : unit_complex_(coeffs) {
-  }
+  SOPHUS_FUNC
+  Map(Scalar* coeffs) : unit_complex_(coeffs) {}
 
-  /**
-   * \brief Accessor of unit complex number
-   *
-   * No direct write access is given to ensure the complex number stays
-   * normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstComplexReference unit_complex() const {
+  /// Accessor of unit complex number.
+  ///
+  SOPHUS_FUNC
+  Map<Sophus::Vector2<Scalar>, Options> const& unit_complex() const {
     return unit_complex_;
   }
 
-protected:
-  // Mutator of complex number is protected so users are hampered
-  // from setting non-unit complex number.
-  EIGEN_STRONG_INLINE
-  ComplexReference unit_complex_nonconst() {
+ protected:
+  /// Mutator of unit_complex is protected to ensure class invariant.
+  ///
+  SOPHUS_FUNC
+  Map<Sophus::Vector2<Scalar>, Options>& unit_complex_nonconst() {
     return unit_complex_;
   }
 
-  Map<Matrix<Scalar,2,1>,_Options> unit_complex_;
+  Map<Matrix<Scalar, 2, 1>, Options> unit_complex_;
 };
 
-/**
- * \brief Specialisation of Eigen::Map for const SO2GroupBase
- *
- * Allows us to wrap SO2 Objects around POD array
- * (e.g. external c style complex number)
- */
-template<typename _Scalar, int _Options>
-class Map<const Sophus::SO2Group<_Scalar>, _Options>
-    : public Sophus::SO2GroupBase<
-    Map<const Sophus::SO2Group<_Scalar>, _Options> > {
-  typedef Sophus::SO2GroupBase<Map<const Sophus::SO2Group<_Scalar>, _Options> >
-  Base;
+/// Specialization of Eigen::Map for ``SO2 const``; derived from SO2Base.
+///
+/// Allows us to wrap SO2 objects around POD array (e.g. external c style
+/// complex number / tuple).
+template <class Scalar_, int Options>
+class Map<Sophus::SO2<Scalar_> const, Options>
+    : public Sophus::SO2Base<Map<Sophus::SO2<Scalar_> const, Options>> {
+ public:
+  using Base = Sophus::SO2Base<Map<Sophus::SO2<Scalar_> const, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief complex number const reference type */
-  typedef const typename internal::traits<Map>::ComplexType &
-  ConstComplexReference;
-
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(const Scalar* coeffs) : unit_complex_(coeffs) {
-  }
+  SOPHUS_FUNC Map(Scalar const* coeffs) : unit_complex_(coeffs) {}
 
-  /**
-   * \brief Accessor of unit complex number
-   *
-   * No direct write access is given to ensure the complex number stays
-   * normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstComplexReference unit_complex() const {
+  /// Accessor of unit complex number.
+  ///
+  SOPHUS_FUNC Map<Sophus::Vector2<Scalar> const, Options> const& unit_complex()
+      const {
     return unit_complex_;
   }
 
-protected:
-  const Map<const Matrix<Scalar,2,1>,_Options> unit_complex_;
+ protected:
+  /// Mutator of unit_complex is protected to ensure class invariant.
+  ///
+  Map<Matrix<Scalar, 2, 1> const, Options> const unit_complex_;
 };
+}  // namespace Eigen
 
-}
-
-
-#endif // SOPHUS_SO2_HPP
+#endif  // SOPHUS_SO2_HPP

--- a/thirdparty/sophus/so3.hpp
+++ b/thirdparty/sophus/so3.hpp
@@ -1,811 +1,855 @@
-// This file is part of Sophus.
-//
-// Copyright 2011-2013 Hauke Strasdat
-// Copyrifht 2012-2013 Steven Lovegrove
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal in the Software without restriction, including without limitation the
-// rights  to use, copy, modify, merge, publish, distribute, sublicense, and/or
-// sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
+/// @file
+/// Special orthogonal group SO(3) - rotation in 3d.
 
 #ifndef SOPHUS_SO3_HPP
 #define SOPHUS_SO3_HPP
 
-#include "sophus.hpp"
+#include "rotation_matrix.hpp"
+#include "so2.hpp"
+#include "types.hpp"
 
-////////////////////////////////////////////////////////////////////////////
-// Forward Declarations / typedefs
-////////////////////////////////////////////////////////////////////////////
+// Include only the selective set of Eigen headers that we need.
+// This helps when using Sophus with unusual compilers, like nvcc.
+#include <Eigen/src/Geometry/OrthoMethods.h>
+#include <Eigen/src/Geometry/Quaternion.h>
+#include <Eigen/src/Geometry/RotationBase.h>
 
 namespace Sophus {
-template<typename _Scalar, int _Options=0> class SO3Group;
-typedef EIGEN_DEPRECATED SO3Group<double> SO3;
-typedef SO3Group<double> SO3d; /**< double precision SO3 */
-typedef SO3Group<float> SO3f;  /**< single precision SO3 */
-}
-
-////////////////////////////////////////////////////////////////////////////
-// Eigen Traits (For querying derived types in CRTP hierarchy)
-////////////////////////////////////////////////////////////////////////////
+template <class Scalar_, int Options = 0>
+class SO3;
+using SO3d = SO3<double>;
+using SO3f = SO3<float>;
+}  // namespace Sophus
 
 namespace Eigen {
 namespace internal {
 
-template<typename _Scalar, int _Options>
-struct traits<Sophus::SO3Group<_Scalar,_Options> > {
-  typedef _Scalar Scalar;
-  typedef Quaternion<Scalar> QuaternionType;
+template <class Scalar_, int Options_>
+struct traits<Sophus::SO3<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using QuaternionType = Eigen::Quaternion<Scalar, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<Sophus::SO3Group<_Scalar>, _Options> >
-    : traits<Sophus::SO3Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<Quaternion<Scalar>,_Options> QuaternionType;
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::SO3<Scalar_>, Options_>>
+    : traits<Sophus::SO3<Scalar_, Options_>> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using QuaternionType = Map<Eigen::Quaternion<Scalar>, Options>;
 };
 
-template<typename _Scalar, int _Options>
-struct traits<Map<const Sophus::SO3Group<_Scalar>, _Options> >
-    : traits<const Sophus::SO3Group<_Scalar, _Options> > {
-  typedef _Scalar Scalar;
-  typedef Map<const Quaternion<Scalar>,_Options> QuaternionType;
+template <class Scalar_, int Options_>
+struct traits<Map<Sophus::SO3<Scalar_> const, Options_>>
+    : traits<Sophus::SO3<Scalar_, Options_> const> {
+  static constexpr int Options = Options_;
+  using Scalar = Scalar_;
+  using QuaternionType = Map<Eigen::Quaternion<Scalar> const, Options>;
 };
-
-}
-}
+}  // namespace internal
+}  // namespace Eigen
 
 namespace Sophus {
-using namespace Eigen;
 
-/**
- * \brief SO3 base type - implements SO3 class but is storage agnostic
- *
- * [add more detailed description/tutorial]
- */
-template<typename Derived>
-class SO3GroupBase {
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Derived>::Scalar Scalar;
-  /** \brief quaternion reference type  */
-  typedef typename internal::traits<Derived>::QuaternionType &
-  QuaternionReference;
-  /** \brief quaternion const reference type  */
-  typedef const typename internal::traits<Derived>::QuaternionType &
-  ConstQuaternionReference;
+/// SO3 base type - implements SO3 class but is storage agnostic.
+///
+/// SO(3) is the group of rotations in 3d. As a matrix group, it is the set of
+/// matrices which are orthogonal such that ``R * R' = I`` (with ``R'`` being
+/// the transpose of ``R``) and have a positive determinant. In particular, the
+/// determinant is 1. Internally, the group is represented as a unit quaternion.
+/// Unit quaternion can be seen as members of the special unitary group SU(2).
+/// SU(2) is a double cover of SO(3). Hence, for every rotation matrix ``R``,
+/// there exist two unit quaternions: ``(r, v)`` and ``(-r, -v)``, with ``r``
+/// the real part and ``v`` being the imaginary 3-vector part of the quaternion.
+///
+/// SO(3) is a compact, but non-commutative group. First it is compact since the
+/// set of rotation matrices is a closed and bounded set. Second it is
+/// non-commutative since the equation ``R_1 * R_2 = R_2 * R_1`` does not hold
+/// in general. For example rotating an object by some degrees about its
+/// ``x``-axis and then by some degrees about its y axis, does not lead to the
+/// same orientation when rotation first about ``y`` and then about ``x``.
+///
+/// Class invariant: The 2-norm of ``unit_quaternion`` must be close to 1.
+/// Technically speaking, it must hold that:
+///
+///   ``|unit_quaternion().squaredNorm() - 1| <= Constants::epsilon()``.
+template <class Derived>
+class SO3Base {
+ public:
+  static constexpr int Options = Eigen::internal::traits<Derived>::Options;
+  using Scalar = typename Eigen::internal::traits<Derived>::Scalar;
+  using QuaternionType =
+      typename Eigen::internal::traits<Derived>::QuaternionType;
+  using QuaternionTemporaryType = Eigen::Quaternion<Scalar, Options>;
 
-  /** \brief degree of freedom of group
-   *         (three for rotation) */
-  static const int DoF = 3;
-  /** \brief number of internal parameters used
-   *         (unit quaternion for rotation) */
-  static const int num_parameters = 4;
-  /** \brief group transformations are NxN matrices */
-  static const int N = 3;
-  /** \brief group transfomation type */
-  typedef Matrix<Scalar,N,N> Transformation;
-  /** \brief point type */
-  typedef Matrix<Scalar,3,1> Point;
-  /** \brief tangent vector type */
-  typedef Matrix<Scalar,DoF,1> Tangent;
-  /** \brief adjoint transformation type */
-  typedef Matrix<Scalar,DoF,DoF> Adjoint;
+  /// Degrees of freedom of group, number of dimensions in tangent space.
+  static int constexpr DoF = 3;
+  /// Number of internal parameters used (quaternion is a 4-tuple).
+  static int constexpr num_parameters = 4;
+  /// Group transformations are 3x3 matrices.
+  static int constexpr N = 3;
+  using Transformation = Matrix<Scalar, N, N>;
+  using Point = Vector3<Scalar>;
+  using HomogeneousPoint = Vector4<Scalar>;
+  using Line = ParametrizedLine3<Scalar>;
+  using Tangent = Vector<Scalar, DoF>;
+  using Adjoint = Matrix<Scalar, DoF, DoF>;
 
-  /**
-   * \brief Adjoint transformation
-   *
-   * This function return the adjoint transformation \f$ Ad \f$ of the
-   * group instance \f$ A \f$  such that for all \f$ x \f$
-   * it holds that \f$ \widehat{Ad_A\cdot x} = A\widehat{x}A^{-1} \f$
-   * with \f$\ \widehat{\cdot} \f$ being the hat()-Vector4Scalaror.
-   *
-   * For SO3, it simply returns the rotation matrix corresponding to \f$ A \f$.
-   */
-  inline
-  const Adjoint Adj() const {
-    return matrix();
+  struct TangentAndTheta {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    Tangent tangent;
+    Scalar theta;
+  };
+
+  /// For binary operations the return type is determined with the
+  /// ScalarBinaryOpTraits feature of Eigen. This allows mixing concrete and Map
+  /// types, as well as other compatible scalar types such as Ceres::Jet and
+  /// double scalars with SO3 operations.
+  template <typename OtherDerived>
+  using ReturnScalar = typename Eigen::ScalarBinaryOpTraits<
+      Scalar, typename OtherDerived::Scalar>::ReturnType;
+
+  template <typename OtherDerived>
+  using SO3Product = SO3<ReturnScalar<OtherDerived>>;
+
+  template <typename PointDerived>
+  using PointProduct = Vector3<ReturnScalar<PointDerived>>;
+
+  template <typename HPointDerived>
+  using HomogeneousPointProduct = Vector4<ReturnScalar<HPointDerived>>;
+
+  /// Adjoint transformation
+  //
+  /// This function return the adjoint transformation ``Ad`` of the group
+  /// element ``A`` such that for all ``x`` it holds that
+  /// ``hat(Ad_A * x) = A * hat(x) A^{-1}``. See hat-operator below.
+  //
+  /// For SO(3), it simply returns the rotation matrix corresponding to ``A``.
+  ///
+  SOPHUS_FUNC Adjoint Adj() const { return matrix(); }
+
+  /// Extract rotation angle about canonical X-axis
+  ///
+  template <class S = Scalar>
+  SOPHUS_FUNC enable_if_t<std::is_floating_point<S>::value, S> angleX() const {
+    Sophus::Matrix3<Scalar> R = matrix();
+    Sophus::Matrix2<Scalar> Rx = R.template block<2, 2>(1, 1);
+    return SO2<Scalar>(makeRotationMatrix(Rx)).log();
   }
 
-  /**
-   * \returns copy of instance casted to NewScalarType
-   */
-  template<typename NewScalarType>
-  inline SO3Group<NewScalarType> cast() const {
-    return SO3Group<NewScalarType>(unit_quaternion()
-                                   .template cast<NewScalarType>() );
+  /// Extract rotation angle about canonical Y-axis
+  ///
+  template <class S = Scalar>
+  SOPHUS_FUNC enable_if_t<std::is_floating_point<S>::value, S> angleY() const {
+    Sophus::Matrix3<Scalar> R = matrix();
+    Sophus::Matrix2<Scalar> Ry;
+    // clang-format off
+    Ry <<
+      R(0, 0), R(2, 0),
+      R(0, 2), R(2, 2);
+    // clang-format on
+    return SO2<Scalar>(makeRotationMatrix(Ry)).log();
   }
 
-  /**
-   * \returns pointer to internal data
-   *
-   * This provides unsafe read/write access to internal data. SO3 is represented
-   * by an Eigen::Quaternion (four parameters). When using direct write access,
-   * the user needs to take care of that the quaternion stays normalized.
-   *
-   * Note: The first three Scalars represent the imaginary parts, while the
-   * forth Scalar represent the real part.
-   *
-   * \see normalize()
-   */
-  inline Scalar* data() {
+  /// Extract rotation angle about canonical Z-axis
+  ///
+  template <class S = Scalar>
+  SOPHUS_FUNC enable_if_t<std::is_floating_point<S>::value, S> angleZ() const {
+    Sophus::Matrix3<Scalar> R = matrix();
+    Sophus::Matrix2<Scalar> Rz = R.template block<2, 2>(0, 0);
+    return SO2<Scalar>(makeRotationMatrix(Rz)).log();
+  }
+
+  /// Returns copy of instance casted to NewScalarType.
+  ///
+  template <class NewScalarType>
+  SOPHUS_FUNC SO3<NewScalarType> cast() const {
+    return SO3<NewScalarType>(unit_quaternion().template cast<NewScalarType>());
+  }
+
+  /// This provides unsafe read/write access to internal data. SO(3) is
+  /// represented by an Eigen::Quaternion (four parameters). When using direct
+  /// write access, the user needs to take care of that the quaternion stays
+  /// normalized.
+  ///
+  /// Note: The first three Scalars represent the imaginary parts, while the
+  /// forth Scalar represent the real part.
+  ///
+  SOPHUS_FUNC Scalar* data() {
     return unit_quaternion_nonconst().coeffs().data();
   }
 
-  /**
-   * \returns const pointer to internal data
-   *
-   * Const version of data().
-   */
-  inline const Scalar* data() const {
+  /// Const version of data() above.
+  ///
+  SOPHUS_FUNC Scalar const* data() const {
     return unit_quaternion().coeffs().data();
   }
 
-  /**
-   * \brief Fast group multiplication
-   *
-   * This method is a fast version of operator*=(), since it does not perform
-   * normalization. It is up to the user to call normalize() once in a while.
-   *
-   * \see operator*=()
-   */
-  inline
-  void fastMultiply(const SO3Group<Scalar>& other) {
-    unit_quaternion_nonconst() *= other.unit_quaternion();
+  /// Returns derivative of  this * SO3::exp(x)  wrt. x at x=0.
+  ///
+  SOPHUS_FUNC Matrix<Scalar, num_parameters, DoF> Dx_this_mul_exp_x_at_0()
+      const {
+    Matrix<Scalar, num_parameters, DoF> J;
+    Eigen::Quaternion<Scalar> const q = unit_quaternion();
+    Scalar const c0 = Scalar(0.5) * q.w();
+    Scalar const c1 = Scalar(0.5) * q.z();
+    Scalar const c2 = -c1;
+    Scalar const c3 = Scalar(0.5) * q.y();
+    Scalar const c4 = Scalar(0.5) * q.x();
+    Scalar const c5 = -c4;
+    Scalar const c6 = -c3;
+    J(0, 0) = c0;
+    J(0, 1) = c2;
+    J(0, 2) = c3;
+    J(1, 0) = c1;
+    J(1, 1) = c0;
+    J(1, 2) = c5;
+    J(2, 0) = c6;
+    J(2, 1) = c4;
+    J(2, 2) = c0;
+    J(3, 0) = c5;
+    J(3, 1) = c6;
+    J(3, 2) = c2;
+
+    return J;
   }
 
-  /**
-   * \returns group inverse of instance
-   */
-  inline
-  const SO3Group<Scalar> inverse() const {
-    return SO3Group<Scalar>(unit_quaternion().conjugate());
+  /// Returns internal parameters of SO(3).
+  ///
+  /// It returns (q.imag[0], q.imag[1], q.imag[2], q.real), with q being the
+  /// unit quaternion.
+  ///
+  SOPHUS_FUNC Sophus::Vector<Scalar, num_parameters> params() const {
+    return unit_quaternion().coeffs();
   }
 
-  /**
-   * \brief Logarithmic map
-   *
-   * \returns tangent space representation (=rotation vector) of instance
-   *
-   * \see  log().
-   */
-  inline
-  const Tangent log() const {
-    return SO3Group<Scalar>::log(*this);
+  /// Returns group inverse.
+  ///
+  SOPHUS_FUNC SO3<Scalar> inverse() const {
+    return SO3<Scalar>(unit_quaternion().conjugate());
   }
 
-  /**
-   * \brief Normalize quaternion
-   *
-   * It re-normalizes unit_quaternion to unit length. This method only needs to
-   * be called in conjunction with fastMultiply() or data() write access.
-   */
-  inline
-  void normalize() {
-    Scalar length = unit_quaternion_nonconst().norm();
-    if (length < SophusConstants<Scalar>::epsilon()) {
-      throw SophusException("Quaternion is (near) zero!");
+  /// Logarithmic map
+  ///
+  /// Computes the logarithm, the inverse of the group exponential which maps
+  /// element of the group (rotation matrices) to elements of the tangent space
+  /// (rotation-vector).
+  ///
+  /// To be specific, this function computes ``vee(logmat(.))`` with
+  /// ``logmat(.)`` being the matrix logarithm and ``vee(.)`` the vee-operator
+  /// of SO(3).
+  ///
+  SOPHUS_FUNC Tangent log() const { return logAndTheta().tangent; }
+
+  /// As above, but also returns ``theta = |omega|``.
+  ///
+  SOPHUS_FUNC TangentAndTheta logAndTheta() const {
+    TangentAndTheta J;
+    using std::abs;
+    using std::atan;
+    using std::sqrt;
+    Scalar squared_n = unit_quaternion().vec().squaredNorm();
+    Scalar w = unit_quaternion().w();
+
+    Scalar two_atan_nbyw_by_n;
+
+    /// Atan-based log thanks to
+    ///
+    /// C. Hertzberg et al.:
+    /// "Integrating Generic Sensor Fusion Algorithms with Sound State
+    /// Representation through Encapsulation of Manifolds"
+    /// Information Fusion, 2011
+
+    if (squared_n < Constants<Scalar>::epsilon() * Constants<Scalar>::epsilon()) {
+      // If quaternion is normalized and n=0, then w should be 1;
+      // w=0 should never happen here!
+      SOPHUS_ENSURE(abs(w) >= Constants<Scalar>::epsilon(),
+                    "Quaternion (%) should be normalized!",
+                    unit_quaternion().coeffs().transpose());
+      Scalar squared_w = w * w;
+      two_atan_nbyw_by_n =
+          Scalar(2) / w - Scalar(2.0/3.0) * (squared_n) / (w * squared_w);
+      J.theta = Scalar(2) * squared_n / w;
+    } else {
+      Scalar n = sqrt(squared_n);
+      if (abs(w) < Constants<Scalar>::epsilon()) {
+        if (w > Scalar(0)) {
+          two_atan_nbyw_by_n = Constants<Scalar>::pi() / n;
+        } else {
+          two_atan_nbyw_by_n = -Constants<Scalar>::pi() / n;
+        }
+      } else {
+        two_atan_nbyw_by_n = Scalar(2) * atan(n / w) / n;
+      }
+      J.theta = two_atan_nbyw_by_n * n;
     }
+
+    J.tangent = two_atan_nbyw_by_n * unit_quaternion().vec();
+    return J;
+  }
+
+  /// It re-normalizes ``unit_quaternion`` to unit length.
+  ///
+  /// Note: Because of the class invariant, there is typically no need to call
+  /// this function directly.
+  ///
+  SOPHUS_FUNC void normalize() {
+    Scalar length = unit_quaternion_nonconst().norm();
+    SOPHUS_ENSURE(length >= Constants<Scalar>::epsilon(),
+                  "Quaternion (%) should not be close to zero!",
+                  unit_quaternion_nonconst().coeffs().transpose());
     unit_quaternion_nonconst().coeffs() /= length;
   }
 
-  /**
-   * \returns 3x3 matrix representation of instance
-   *
-   * For SO3, the matrix representation is an orthogonal matrix R with det(R)=1,
-   * thus the so-called rotation matrix.
-   */
-  inline
-  const Transformation matrix() const {
+  /// Returns 3x3 matrix representation of the instance.
+  ///
+  /// For SO(3), the matrix representation is an orthogonal matrix ``R`` with
+  /// ``det(R)=1``, thus the so-called "rotation matrix".
+  ///
+  SOPHUS_FUNC Transformation matrix() const {
     return unit_quaternion().toRotationMatrix();
   }
 
-  /**
-   * \brief Assignment operator
-   */
-  template<typename OtherDerived> inline
-  SO3GroupBase<Derived>& operator=(const SO3GroupBase<OtherDerived> & other) {
+  /// Assignment operator.
+  ///
+  SOPHUS_FUNC SO3Base& operator=(SO3Base const& other) = default;
+
+  /// Assignment-like operator from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC SO3Base<Derived>& operator=(SO3Base<OtherDerived> const& other) {
     unit_quaternion_nonconst() = other.unit_quaternion();
     return *this;
   }
 
-  /**
-   * \brief Group multiplication
-   * \see operator*=()
-   */
-  inline
-  const SO3Group<Scalar> operator*(const SO3Group<Scalar>& other) const {
-    SO3Group<Scalar> result(*this);
-    result *= other;
-    return result;
+  /// Group multiplication, which is rotation concatenation.
+  ///
+  template <typename OtherDerived>
+  SOPHUS_FUNC SO3Product<OtherDerived> operator*(
+      SO3Base<OtherDerived> const& other) const {
+    using QuaternionProductType =
+        typename SO3Product<OtherDerived>::QuaternionType;
+    const QuaternionType& a = unit_quaternion();
+    const typename OtherDerived::QuaternionType& b = other.unit_quaternion();
+    /// NOTE: We cannot use Eigen's Quaternion multiplication because it always
+    /// returns a Quaternion of the same Scalar as this object, so it is not
+    /// able to multiple Jets and doubles correctly.
+    return SO3Product<OtherDerived>(QuaternionProductType(
+        a.w() * b.w() - a.x() * b.x() - a.y() * b.y() - a.z() * b.z(),
+        a.w() * b.x() + a.x() * b.w() + a.y() * b.z() - a.z() * b.y(),
+        a.w() * b.y() + a.y() * b.w() + a.z() * b.x() - a.x() * b.z(),
+        a.w() * b.z() + a.z() * b.w() + a.x() * b.y() - a.y() * b.x()));
   }
 
-  /**
-   * \brief Group action on \f$ \mathbf{R}^3 \f$
-   *
-   * \param p point \f$p \in \mathbf{R}^3 \f$
-   * \returns point \f$p' \in \mathbf{R}^3 \f$, rotated version of \f$p\f$
-   *
-   * This function rotates a point \f$ p \f$ in  \f$ \mathbf{R}^3 \f$ by the
-   * SO3 transformation \f$R\f$ (=rotation matrix): \f$ p' = R\cdot p \f$.
-   *
-   *
-   * Since SO3 is intenally represented by a unit quaternion \f$q\f$, it is
-   * implemented as \f$ p' = q\cdot p \cdot q^{*} \f$
-   * with \f$ q^{*} \f$ being the quaternion conjugate of \f$ q \f$.
-   *
-   * Geometrically, \f$ p \f$  is rotated by angle \f$|\omega|\f$ around the
-   * axis \f$\frac{\omega}{|\omega|}\f$ with \f$ \omega = \log(R)^\vee \f$.
-   *
-   * \see log()
-   */
-  inline
-  const Point operator*(const Point & p) const {
-    return unit_quaternion()._transformVector(p);
+  /// Group action on 3-points.
+  ///
+  /// This function rotates a 3 dimensional point ``p`` by the SO3 element
+  ///  ``bar_R_foo`` (= rotation matrix): ``p_bar = bar_R_foo * p_foo``.
+  ///
+  /// Since SO3 is internally represented by a unit quaternion ``q``, it is
+  /// implemented as ``p_bar = q * p_foo * q^{*}``
+  /// with ``q^{*}`` being the quaternion conjugate of ``q``.
+  ///
+  /// Geometrically, ``p``  is rotated by angle ``|omega|`` around the
+  /// axis ``omega/|omega|`` with ``omega := vee(log(bar_R_foo))``.
+  ///
+  /// For ``vee``-operator, see below.
+  ///
+  template <typename PointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<PointDerived, 3>::value>::type>
+  SOPHUS_FUNC PointProduct<PointDerived> operator*(
+      Eigen::MatrixBase<PointDerived> const& p) const {
+    /// NOTE: We cannot use Eigen's Quaternion transformVector because it always
+    /// returns a Vector3 of the same Scalar as this quaternion, so it is not
+    /// able to be applied to Jets and doubles correctly.
+    const QuaternionType& q = unit_quaternion();
+    PointProduct<PointDerived> uv = q.vec().cross(p);
+    uv += uv;
+    return p + q.w() * uv + q.vec().cross(uv);
   }
 
-  /**
-   * \brief In-place group multiplication
-   *
-   * \see fastMultiply()
-   * \see operator*()
-   */
-  inline
-  void operator*=(const SO3Group<Scalar>& other) {
-    fastMultiply(other);
-    normalize();
+  /// Group action on homogeneous 3-points. See above for more details.
+  template <typename HPointDerived,
+            typename = typename std::enable_if<
+                IsFixedSizeVector<HPointDerived, 4>::value>::type>
+  SOPHUS_FUNC HomogeneousPointProduct<HPointDerived> operator*(
+      Eigen::MatrixBase<HPointDerived> const& p) const {
+    const auto rp = *this * p.template head<3>();
+    return HomogeneousPointProduct<HPointDerived>(rp(0), rp(1), rp(2), p(3));
   }
 
-  /**
-   * \brief Setter of internal unit quaternion representation
-   *
-   * \param quaternion
-   * \pre   the quaternion must not be zero
-   *
-   * The quaternion is normalized to unit length.
-   */
-  inline
-  void setQuaternion(const Quaternion<Scalar>& quaternion) {
+  /// Group action on lines.
+  ///
+  /// This function rotates a parametrized line ``l(t) = o + t * d`` by the SO3
+  /// element:
+  ///
+  /// Both direction ``d`` and origin ``o`` are rotated as a 3 dimensional point
+  ///
+  SOPHUS_FUNC Line operator*(Line const& l) const {
+    return Line((*this) * l.origin(), (*this) * l.direction());
+  }
+
+  /// In-place group multiplication. This method is only valid if the return
+  /// type of the multiplication is compatible with this SO3's Scalar type.
+  ///
+  template <typename OtherDerived,
+            typename = typename std::enable_if<
+                std::is_same<Scalar, ReturnScalar<OtherDerived>>::value>::type>
+  SOPHUS_FUNC SO3Base<Derived>& operator*=(SO3Base<OtherDerived> const& other) {
+    *static_cast<Derived*>(this) = *this * other;
+    return *this;
+  }
+
+  /// Takes in quaternion, and normalizes it.
+  ///
+  /// Precondition: The quaternion must not be close to zero.
+  ///
+  SOPHUS_FUNC void setQuaternion(Eigen::Quaternion<Scalar> const& quaternion) {
     unit_quaternion_nonconst() = quaternion;
     normalize();
   }
 
-  /**
-   * \brief Accessor of unit quaternion
-   *
-   * No direct write access is given to ensure the quaternion stays normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstQuaternionReference unit_quaternion() const {
-    return static_cast<const Derived*>(this)->unit_quaternion();
+  /// Accessor of unit quaternion.
+  ///
+  SOPHUS_FUNC QuaternionType const& unit_quaternion() const {
+    return static_cast<Derived const*>(this)->unit_quaternion();
   }
 
-  ////////////////////////////////////////////////////////////////////////////
-  // public static functions
-  ////////////////////////////////////////////////////////////////////////////
+ private:
+  /// Mutator of unit_quaternion is private to ensure class invariant. That is
+  /// the quaternion must stay close to unit length.
+  ///
+  SOPHUS_FUNC QuaternionType& unit_quaternion_nonconst() {
+    return static_cast<Derived*>(this)->unit_quaternion_nonconst();
+  }
+};
 
-  /**
-   * \param   b 3-vector representation of Lie algebra element
-   * \returns   derivative of Lie bracket
-   *
-   * This function returns \f$ \frac{\partial}{\partial a} [a, b]_{so3} \f$
-   * with \f$ [a, b]_{so3} \f$ being the lieBracket() of the Lie algebra so3.
-   *
-   * \see lieBracket()
-   */
-  inline static
-  const Adjoint d_lieBracketab_by_d_a(const Tangent & b) {
-    return -hat(b);
+/// SO3 using default storage; derived from SO3Base.
+template <class Scalar_, int Options>
+class SO3 : public SO3Base<SO3<Scalar_, Options>> {
+ public:
+  using Base = SO3Base<SO3<Scalar_, Options>>;
+  static int constexpr DoF = Base::DoF;
+  static int constexpr num_parameters = Base::num_parameters;
+
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
+  using QuaternionMember = Eigen::Quaternion<Scalar, Options>;
+
+  /// ``Base`` is friend so unit_quaternion_nonconst can be accessed from
+  /// ``Base``.
+  friend class SO3Base<SO3<Scalar, Options>>;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /// Default constructor initializes unit quaternion to identity rotation.
+  ///
+  SOPHUS_FUNC SO3()
+      : unit_quaternion_(Scalar(1), Scalar(0), Scalar(0), Scalar(0)) {}
+
+  /// Copy constructor
+  ///
+  SOPHUS_FUNC SO3(SO3 const& other) = default;
+
+  /// Copy-like constructor from OtherDerived.
+  ///
+  template <class OtherDerived>
+  SOPHUS_FUNC SO3(SO3Base<OtherDerived> const& other)
+      : unit_quaternion_(other.unit_quaternion()) {}
+
+  /// Constructor from rotation matrix
+  ///
+  /// Precondition: rotation matrix needs to be orthogonal with determinant
+  /// of 1.
+  ///
+  SOPHUS_FUNC SO3(Transformation const& R) : unit_quaternion_(R) {
+    SOPHUS_ENSURE(isOrthogonal(R), "R is not orthogonal:\n %",
+                  R * R.transpose());
+    SOPHUS_ENSURE(R.determinant() > Scalar(0), "det(R) is not positive: %",
+                  R.determinant());
   }
 
-  /**
-   * \brief Group exponential
-   *
-   * \param omega tangent space element (=rotation vector \f$ \omega \f$)
-   * \returns     corresponding element of the group SO3
-   *
-   * To be more specific, this function computes \f$ \exp(\widehat{\omega}) \f$
-   * with \f$ \exp(\cdot) \f$ being the matrix exponential
-   * and \f$ \widehat{\cdot} \f$ the hat()-operator of SO3.
-   *
-   * \see expAndTheta()
-   * \see hat()
-   * \see log()
-   */
-  inline static
-  const SO3Group<Scalar> exp(const Tangent & omega) {
+  /// Constructor from quaternion
+  ///
+  /// Precondition: quaternion must not be close to zero.
+  ///
+  template <class D>
+  SOPHUS_FUNC explicit SO3(Eigen::QuaternionBase<D> const& quat)
+      : unit_quaternion_(quat) {
+    static_assert(
+        std::is_same<typename Eigen::QuaternionBase<D>::Scalar, Scalar>::value,
+        "Input must be of same scalar type");
+    Base::normalize();
+  }
+
+  /// Accessor of unit quaternion.
+  ///
+  SOPHUS_FUNC QuaternionMember const& unit_quaternion() const {
+    return unit_quaternion_;
+  }
+
+  /// Returns derivative of exp(x) wrt. x.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF> Dx_exp_x(
+      Tangent const& omega) {
+    using std::cos;
+    using std::exp;
+    using std::sin;
+    using std::sqrt;
+    Scalar const c0 = omega[0] * omega[0];
+    Scalar const c1 = omega[1] * omega[1];
+    Scalar const c2 = omega[2] * omega[2];
+    Scalar const c3 = c0 + c1 + c2;
+
+    if (c3 < Constants<Scalar>::epsilon()) {
+      return Dx_exp_x_at_0();
+    }
+
+    Scalar const c4 = sqrt(c3);
+    Scalar const c5 = 1.0 / c4;
+    Scalar const c6 = 0.5 * c4;
+    Scalar const c7 = sin(c6);
+    Scalar const c8 = c5 * c7;
+    Scalar const c9 = pow(c3, -3.0L / 2.0L);
+    Scalar const c10 = c7 * c9;
+    Scalar const c11 = Scalar(1.0) / c3;
+    Scalar const c12 = cos(c6);
+    Scalar const c13 = Scalar(0.5) * c11 * c12;
+    Scalar const c14 = c7 * c9 * omega[0];
+    Scalar const c15 = Scalar(0.5) * c11 * c12 * omega[0];
+    Scalar const c16 = -c14 * omega[1] + c15 * omega[1];
+    Scalar const c17 = -c14 * omega[2] + c15 * omega[2];
+    Scalar const c18 = omega[1] * omega[2];
+    Scalar const c19 = -c10 * c18 + c13 * c18;
+    Scalar const c20 = Scalar(0.5) * c5 * c7;
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    J(0, 0) = -c0 * c10 + c0 * c13 + c8;
+    J(0, 1) = c16;
+    J(0, 2) = c17;
+    J(1, 0) = c16;
+    J(1, 1) = -c1 * c10 + c1 * c13 + c8;
+    J(1, 2) = c19;
+    J(2, 0) = c17;
+    J(2, 1) = c19;
+    J(2, 2) = -c10 * c2 + c13 * c2 + c8;
+    J(3, 0) = -c20 * omega[0];
+    J(3, 1) = -c20 * omega[1];
+    J(3, 2) = -c20 * omega[2];
+    return J;
+  }
+
+  /// Returns derivative of exp(x) wrt. x_i at x=0.
+  ///
+  SOPHUS_FUNC static Sophus::Matrix<Scalar, num_parameters, DoF>
+  Dx_exp_x_at_0() {
+    Sophus::Matrix<Scalar, num_parameters, DoF> J;
+    // clang-format off
+    J <<  Scalar(0.5),   Scalar(0),   Scalar(0),
+            Scalar(0), Scalar(0.5),   Scalar(0),
+            Scalar(0),   Scalar(0), Scalar(0.5),
+            Scalar(0),   Scalar(0),   Scalar(0);
+    // clang-format on
+    return J;
+  }
+
+  /// Returns derivative of exp(x).matrix() wrt. ``x_i at x=0``.
+  ///
+  SOPHUS_FUNC static Transformation Dxi_exp_x_matrix_at_0(int i) {
+    return generator(i);
+  }
+
+  /// Group exponential
+  ///
+  /// This functions takes in an element of tangent space (= rotation vector
+  /// ``omega``) and returns the corresponding element of the group SO(3).
+  ///
+  /// To be more specific, this function computes ``expmat(hat(omega))``
+  /// with ``expmat(.)`` being the matrix exponential and ``hat(.)`` being the
+  /// hat()-operator of SO(3).
+  ///
+  SOPHUS_FUNC static SO3<Scalar> exp(Tangent const& omega) {
     Scalar theta;
     return expAndTheta(omega, &theta);
   }
 
-  /**
-   * \brief Group exponential and theta
-   *
-   * \param      omega tangent space element (=rotation vector \f$ \omega \f$)
-   * \param[out] theta angle of rotation \f$ \theta = |\omega| \f$
-   * \returns          corresponding element of the group SO3
-   *
-   * \see exp() for details
-   */
-  inline static
-  const SO3Group<Scalar> expAndTheta(const Tangent & omega,
-                                     Scalar * theta) {
-    const Scalar theta_sq = omega.squaredNorm();
-    *theta = std::sqrt(theta_sq);
-    const Scalar half_theta = static_cast<Scalar>(0.5)*(*theta);
+  /// As above, but also returns ``theta = |omega|`` as out-parameter.
+  ///
+  /// Precondition: ``theta`` must not be ``nullptr``.
+  ///
+  SOPHUS_FUNC static SO3<Scalar> expAndTheta(Tangent const& omega,
+                                             Scalar* theta) {
+    SOPHUS_ENSURE(theta != nullptr, "must not be nullptr.");
+    using std::abs;
+    using std::cos;
+    using std::sin;
+    using std::sqrt;
+    Scalar theta_sq = omega.squaredNorm();
 
     Scalar imag_factor;
-    Scalar real_factor;;
-    if((*theta)<SophusConstants<Scalar>::epsilon()) {
-      const Scalar theta_po4 = theta_sq*theta_sq;
-      imag_factor = static_cast<Scalar>(0.5)
-                    - static_cast<Scalar>(1.0/48.0)*theta_sq
-                    + static_cast<Scalar>(1.0/3840.0)*theta_po4;
-      real_factor = static_cast<Scalar>(1)
-                    - static_cast<Scalar>(0.5)*theta_sq +
-                    static_cast<Scalar>(1.0/384.0)*theta_po4;
+    Scalar real_factor;
+    if (theta_sq <
+        Constants<Scalar>::epsilon() * Constants<Scalar>::epsilon()) {
+      *theta = Scalar(0);
+      Scalar theta_po4 = theta_sq * theta_sq;
+      imag_factor = Scalar(0.5) - Scalar(1.0 / 48.0) * theta_sq +
+                    Scalar(1.0 / 3840.0) * theta_po4;
+      real_factor = Scalar(1) - Scalar(1.0 / 8.0) * theta_sq +
+                    Scalar(1.0 / 384.0) * theta_po4;
     } else {
-      const Scalar sin_half_theta = std::sin(half_theta);
-      imag_factor = sin_half_theta/(*theta);
-      real_factor = std::cos(half_theta);
+      *theta = sqrt(theta_sq);
+      Scalar half_theta = Scalar(0.5) * (*theta);
+      Scalar sin_half_theta = sin(half_theta);
+      imag_factor = sin_half_theta / (*theta);
+      real_factor = cos(half_theta);
     }
 
-    return SO3Group<Scalar>(Quaternion<Scalar>(real_factor,
-                                               imag_factor*omega.x(),
-                                               imag_factor*omega.y(),
-                                               imag_factor*omega.z()));
+    SO3 q;
+    q.unit_quaternion_nonconst() =
+        QuaternionMember(real_factor, imag_factor * omega.x(),
+                         imag_factor * omega.y(), imag_factor * omega.z());
+    SOPHUS_ENSURE(abs(q.unit_quaternion().squaredNorm() - Scalar(1)) <
+                      Sophus::Constants<Scalar>::epsilon(),
+                  "SO3::exp failed! omega: %, real: %, img: %",
+                  omega.transpose(), real_factor, imag_factor);
+    return q;
   }
 
-  /**
-   * \brief Generators
-   *
-   * \pre \f$ i \in \{0,1,2\} \f$
-   * \returns \f$ i \f$th generator \f$ G_i \f$ of SO3
-   *
-   * The infinitesimal generators of SO3
-   * are \f$
-   *        G_0 = \left( \begin{array}{ccc}
-   *                          0&  0&  0& \\
-   *                          0&  0& -1& \\
-   *                          0&  1&  0&
-   *                     \end{array} \right),
-   *        G_1 = \left( \begin{array}{ccc}
-   *                          0&  0&  1& \\
-   *                          0&  0&  0& \\
-   *                         -1&  0&  0&
-   *                     \end{array} \right),
-   *        G_2 = \left( \begin{array}{ccc}
-   *                          0& -1&  0& \\
-   *                          1&  0&  0& \\
-   *                          0&  0&  0&
-   *                     \end{array} \right).
-   * \f$
-   * \see hat()
-   */
-  inline static
-  const Transformation generator(int i) {
-    if (i<0 || i>2) {
-      throw SophusException("i is not in range [0,2].");
-    }
+  /// Returns closest SO3 given arbitrary 3x3 matrix.
+  ///
+  template <class S = Scalar>
+  static SOPHUS_FUNC enable_if_t<std::is_floating_point<S>::value, SO3>
+  fitToSO3(Transformation const& R) {
+    return SO3(::Sophus::makeRotationMatrix(R));
+  }
+
+  /// Returns the ith infinitesimal generators of SO(3).
+  ///
+  /// The infinitesimal generators of SO(3) are:
+  ///
+  /// ```
+  ///         |  0  0  0 |
+  ///   G_0 = |  0  0 -1 |
+  ///         |  0  1  0 |
+  ///
+  ///         |  0  0  1 |
+  ///   G_1 = |  0  0  0 |
+  ///         | -1  0  0 |
+  ///
+  ///         |  0 -1  0 |
+  ///   G_2 = |  1  0  0 |
+  ///         |  0  0  0 |
+  /// ```
+  ///
+  /// Precondition: ``i`` must be 0, 1 or 2.
+  ///
+  SOPHUS_FUNC static Transformation generator(int i) {
+    SOPHUS_ENSURE(i >= 0 && i <= 2, "i should be in range [0,2].");
     Tangent e;
     e.setZero();
-    e[i] = static_cast<Scalar>(1);
+    e[i] = Scalar(1);
     return hat(e);
   }
 
-  /**
-   * \brief hat-operator
-   *
-   * \param omega 3-vector representation of Lie algebra element
-   * \returns     3x3-matrix representatin of Lie algebra element
-   *
-   * Formally, the hat-operator of SO3 is defined
-   * as \f$ \widehat{\cdot}: \mathbf{R}^3 \rightarrow \mathbf{R}^{3\times 3},
-   * \quad \widehat{\omega} = \sum_{i=0}^2 G_i \omega_i \f$
-   * with \f$ G_i \f$ being the ith infinitesial generator().
-   *
-   * \see generator()
-   * \see vee()
-   */
-  inline static
-  const Transformation hat(const Tangent & omega) {
+  /// hat-operator
+  ///
+  /// It takes in the 3-vector representation ``omega`` (= rotation vector) and
+  /// returns the corresponding matrix representation of Lie algebra element.
+  ///
+  /// Formally, the hat()-operator of SO(3) is defined as
+  ///
+  ///   ``hat(.): R^3 -> R^{3x3},  hat(omega) = sum_i omega_i * G_i``
+  ///   (for i=0,1,2)
+  ///
+  /// with ``G_i`` being the ith infinitesimal generator of SO(3).
+  ///
+  /// The corresponding inverse is the vee()-operator, see below.
+  ///
+  SOPHUS_FUNC static Transformation hat(Tangent const& omega) {
     Transformation Omega;
-    Omega <<  static_cast<Scalar>(0), -omega(2),  omega(1)
-        ,  omega(2),     static_cast<Scalar>(0), -omega(0)
-        , -omega(1),  omega(0),     static_cast<Scalar>(0);
+    // clang-format off
+    Omega <<
+        Scalar(0), -omega(2),  omega(1),
+         omega(2), Scalar(0), -omega(0),
+        -omega(1),  omega(0), Scalar(0);
+    // clang-format on
     return Omega;
   }
 
-  /**
-   * \brief Lie bracket
-   *
-   * \param omega1 3-vector representation of Lie algebra element
-   * \param omega2 3-vector representation of Lie algebra element
-   * \returns      3-vector representation of Lie algebra element
-   *
-   * It computes the bracket of SO3. To be more specific, it
-   * computes \f$ [\omega_1, \omega_2]_{so3}
-   * := [\widehat{\omega_1}, \widehat{\omega_2}]^\vee \f$
-   * with \f$ [A,B] = AB-BA \f$ being the matrix
-   * commutator, \f$ \widehat{\cdot} \f$ the
-   * hat()-operator and \f$ (\cdot)^\vee \f$ the vee()-operator of SO3.
-   *
-   * For the Lie algebra so3, the Lie bracket is simply the
-   * cross product: \f$ [\omega_1, \omega_2]_{so3}
-   *                    = \omega_1 \times \omega_2 \f$.
-   *
-   * \see hat()
-   * \see vee()
-   */
-  inline static
-  const Tangent lieBracket(const Tangent & omega1,
-                           const Tangent & omega2) {
+  /// Lie bracket
+  ///
+  /// It computes the Lie bracket of SO(3). To be more specific, it computes
+  ///
+  ///   ``[omega_1, omega_2]_so3 := vee([hat(omega_1), hat(omega_2)])``
+  ///
+  /// with ``[A,B] := AB-BA`` being the matrix commutator, ``hat(.)`` the
+  /// hat()-operator and ``vee(.)`` the vee()-operator of SO3.
+  ///
+  /// For the Lie algebra so3, the Lie bracket is simply the cross product:
+  ///
+  /// ``[omega_1, omega_2]_so3 = omega_1 x omega_2.``
+  ///
+  SOPHUS_FUNC static Tangent lieBracket(Tangent const& omega1,
+                                        Tangent const& omega2) {
     return omega1.cross(omega2);
   }
 
-  /**
-   * \brief Logarithmic map
-   *
-   * \param other element of the group SO3
-   * \returns     corresponding tangent space element
-   *              (=rotation vector \f$ \omega \f$)
-   *
-   * Computes the logarithmic, the inverse of the group exponential.
-   * To be specific, this function computes \f$ \log({\cdot})^\vee \f$
-   * with \f$ \vee(\cdot) \f$ being the matrix logarithm
-   * and \f$ \vee{\cdot} \f$ the vee()-operator of SO3.
-   *
-   * \see exp()
-   * \see logAndTheta()
-   * \see vee()
-   */
-  inline static
-  const Tangent log(const SO3Group<Scalar> & other) {
-    Scalar theta;
-    return logAndTheta(other, &theta);
+  /// Construct x-axis rotation.
+  ///
+  static SOPHUS_FUNC SO3 rotX(Scalar const& x) {
+    return SO3::exp(Sophus::Vector3<Scalar>(x, Scalar(0), Scalar(0)));
   }
 
-  /**
-   * \brief Logarithmic map and theta
-   *
-   * \param      other element of the group SO3
-   * \param[out] theta angle of rotation \f$ \theta = |\omega| \f$
-   * \returns          corresponding tangent space element
-   *                   (=rotation vector \f$ \omega \f$)
-   *
-   * \see log() for details
-   */
-  inline static
-  const Tangent logAndTheta(const SO3Group<Scalar> & other,
-                            Scalar * theta) {
-    const Scalar squared_n
-        = other.unit_quaternion().vec().squaredNorm();
-    const Scalar n = std::sqrt(squared_n);
-    const Scalar w = other.unit_quaternion().w();
-
-    Scalar two_atan_nbyw_by_n;
-
-    // Atan-based log thanks to
-    //
-    // C. Hertzberg et al.:
-    // "Integrating Generic Sensor Fusion Algorithms with Sound State
-    // Representation through Encapsulation of Manifolds"
-    // Information Fusion, 2011
-
-    if (n < SophusConstants<Scalar>::epsilon()) {
-      // If quaternion is normalized and n=0, then w should be 1;
-      // w=0 should never happen here!
-      if (std::abs(w) < SophusConstants<Scalar>::epsilon()) {
-        throw SophusException("Quaternion is not normalized!");
-      }
-      const Scalar squared_w = w*w;
-      two_atan_nbyw_by_n = static_cast<Scalar>(2) / w
-                           - static_cast<Scalar>(2)*(squared_n)/(w*squared_w);
-    } else {
-      if (std::abs(w)<SophusConstants<Scalar>::epsilon()) {
-        if (w > static_cast<Scalar>(0)) {
-          two_atan_nbyw_by_n = M_PI/n;
-        } else {
-          two_atan_nbyw_by_n = -M_PI/n;
-        }
-      }else{
-        two_atan_nbyw_by_n = static_cast<Scalar>(2) * atan(n/w) / n;
-      }
-    }
-
-    *theta = two_atan_nbyw_by_n*n;
-
-    return two_atan_nbyw_by_n * other.unit_quaternion().vec();
+  /// Construct y-axis rotation.
+  ///
+  static SOPHUS_FUNC SO3 rotY(Scalar const& y) {
+    return SO3::exp(Sophus::Vector3<Scalar>(Scalar(0), y, Scalar(0)));
   }
 
-  /**
-   * \brief vee-operator
-   *
-   * \param Omega 3x3-matrix representation of Lie algebra element
-   * \pr          Omega must be a skew-symmetric matrix
-   * \returns     3-vector representatin of Lie algebra element
-   *
-   * This is the inverse of the hat()-operator.
-   *
-   * \see hat()
-   */
-  inline static
-  const Tangent vee(const Transformation & Omega) {
-    return static_cast<Scalar>(0.5) * Tangent(Omega(2,1) - Omega(1,2),
-                                              Omega(0,2) - Omega(2,0),
-                                              Omega(1,0) - Omega(0,1));
+  /// Construct z-axis rotation.
+  ///
+  static SOPHUS_FUNC SO3 rotZ(Scalar const& z) {
+    return SO3::exp(Sophus::Vector3<Scalar>(Scalar(0), Scalar(0), z));
   }
 
-private:
-  // Mutator of unit_quaternion is private so users are hampered
-  // from setting non-unit quaternions.
-  EIGEN_STRONG_INLINE
-  QuaternionReference unit_quaternion_nonconst() {
-    return static_cast<Derived*>(this)->unit_quaternion_nonconst();
+  /// Draw uniform sample from SO(3) manifold.
+  /// Based on: http://planning.cs.uiuc.edu/node198.html
+  ///
+  template <class UniformRandomBitGenerator>
+  static SO3 sampleUniform(UniformRandomBitGenerator& generator) {
+    static_assert(IsUniformRandomBitGenerator<UniformRandomBitGenerator>::value,
+                  "generator must meet the UniformRandomBitGenerator concept");
+
+    std::uniform_real_distribution<Scalar> uniform(Scalar(0), Scalar(1));
+    std::uniform_real_distribution<Scalar> uniform_twopi(
+        Scalar(0), 2 * Constants<Scalar>::pi());
+
+    const Scalar u1 = uniform(generator);
+    const Scalar u2 = uniform_twopi(generator);
+    const Scalar u3 = uniform_twopi(generator);
+
+    const Scalar a = sqrt(1 - u1);
+    const Scalar b = sqrt(u1);
+
+    return SO3(
+        QuaternionMember(a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3)));
   }
 
-};
-
-/**
- * \brief SO3 default type - Constructors and default storage for SO3 Type
- */
-template<typename _Scalar, int _Options>
-class SO3Group : public SO3GroupBase<SO3Group<_Scalar,_Options> > {
-  typedef SO3GroupBase<SO3Group<_Scalar,_Options> > Base;
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<SO3Group<_Scalar,_Options> >
-  ::Scalar Scalar;
-  /** \brief quaternion type */
-  typedef typename internal::traits<SO3Group<_Scalar,_Options> >
-  ::QuaternionType & QuaternionReference;
-  typedef const typename internal::traits<SO3Group<_Scalar,_Options> >
-  ::QuaternionType & ConstQuaternionReference;
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
-  // base is friend so unit_quaternion_nonconst can be accessed from base
-  friend class SO3GroupBase<SO3Group<_Scalar,_Options> >;
-
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-  /**
-   * \brief Default constructor
-   *
-   * Initialize Quaternion to identity rotation.
-   */
-  inline
-  SO3Group()
-    : unit_quaternion_(static_cast<Scalar>(1), static_cast<Scalar>(0),
-                       static_cast<Scalar>(0), static_cast<Scalar>(0)) {
+  /// vee-operator
+  ///
+  /// It takes the 3x3-matrix representation ``Omega`` and maps it to the
+  /// corresponding vector representation of Lie algebra.
+  ///
+  /// This is the inverse of the hat()-operator, see above.
+  ///
+  /// Precondition: ``Omega`` must have the following structure:
+  ///
+  ///                |  0 -c  b |
+  ///                |  c  0 -a |
+  ///                | -b  a  0 |
+  ///
+  SOPHUS_FUNC static Tangent vee(Transformation const& Omega) {
+    return Tangent(Omega(2, 1), Omega(0, 2), Omega(1, 0));
   }
 
-  /**
-   * \brief Copy constructor
-   */
-  template<typename OtherDerived> inline
-  SO3Group(const SO3GroupBase<OtherDerived> & other)
-    : unit_quaternion_(other.unit_quaternion()) {
-  }
-
-  /**
-   * \brief Constructor from rotation matrix
-   *
-   * \pre rotation matrix need to be orthogonal with determinant of 1
-   */
-  inline SO3Group(const Transformation & R)
-    : unit_quaternion_(R) {
-  }
-
-  /**
-   * \brief Constructor from quaternion
-   *
-   * \pre quaternion must not be zero
-   */
-  inline explicit
-  SO3Group(const Quaternion<Scalar> & quat) : unit_quaternion_(quat) {
-    Base::normalize();
-  }
-
-  /**
-   * \brief Constructor from Euler angles
-   *
-   * \param alpha1 rotation around x-axis
-   * \param alpha2 rotation around y-axis
-   * \param alpha3 rotation around z-axis
-   *
-   * Since rotations in 3D do not commute, the order of the individual rotations
-   * matter. Here, the following convention is used. We calculate a SO3 member
-   * corresponding to the rotation matrix \f$ R \f$ such
-   * that \f$ R=\exp\left(\begin{array}{c}\alpha_1\\ 0\\ 0\end{array}\right)
-   *    \cdot   \exp\left(\begin{array}{c}0\\ \alpha_2\\ 0\end{array}\right)
-   *    \cdot   \exp\left(\begin{array}{c}0\\ 0\\ \alpha_3\end{array}\right)\f$.
-   */
-  inline
-  SO3Group(Scalar alpha1, Scalar alpha2, Scalar alpha3) {
-    const static Scalar zero = static_cast<Scalar>(0);
-    unit_quaternion_
-        = ( SO3Group::exp(Tangent(alpha1,   zero,   zero))
-            *SO3Group::exp(Tangent(  zero, alpha2,   zero))
-            *SO3Group::exp(Tangent(  zero,   zero, alpha3)) )
-          .unit_quaternion_;
-  }
-
-  /**
-   * \brief Accessor of unit quaternion
-   *
-   * No direct write access is given to ensure the quaternion stays normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstQuaternionReference unit_quaternion() const {
+ protected:
+  /// Mutator of unit_quaternion is protected to ensure class invariant.
+  ///
+  SOPHUS_FUNC QuaternionMember& unit_quaternion_nonconst() {
     return unit_quaternion_;
   }
 
-protected:
-  // Mutator of unit_quaternion is protected so users are hampered
-  // from setting non-unit quaternions.
-  EIGEN_STRONG_INLINE
-  QuaternionReference unit_quaternion_nonconst() {
-    return unit_quaternion_;
-  }
-
-  Quaternion<Scalar> unit_quaternion_;
+  QuaternionMember unit_quaternion_;
 };
 
-} // end namespace
-
+}  // namespace Sophus
 
 namespace Eigen {
-/**
- * \brief Specialisation of Eigen::Map for SO3GroupBase
- *
- * Allows us to wrap SO3 Objects around POD array
- * (e.g. external c style quaternion)
- */
-template<typename _Scalar, int _Options>
-class Map<Sophus::SO3Group<_Scalar>, _Options>
-    : public Sophus::SO3GroupBase<Map<Sophus::SO3Group<_Scalar>, _Options> > {
-  typedef Sophus::SO3GroupBase<Map<Sophus::SO3Group<_Scalar>, _Options> > Base;
+/// Specialization of Eigen::Map for ``SO3``; derived from SO3Base.
+///
+/// Allows us to wrap SO3 objects around POD array (e.g. external c style
+/// quaternion).
+template <class Scalar_, int Options>
+class Map<Sophus::SO3<Scalar_>, Options>
+    : public Sophus::SO3Base<Map<Sophus::SO3<Scalar_>, Options>> {
+ public:
+  using Base = Sophus::SO3Base<Map<Sophus::SO3<Scalar_>, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief quaternion reference type */
-  typedef typename internal::traits<Map>::QuaternionType &
-  QuaternionReference;
-  /** \brief quaternion const reference type */
-  typedef const typename internal::traits<Map>::QuaternionType &
-  ConstQuaternionReference;
+  /// ``Base`` is friend so unit_quaternion_nonconst can be accessed from
+  /// ``Base``.
+  friend class Sophus::SO3Base<Map<Sophus::SO3<Scalar_>, Options>>;
 
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
+  // LCOV_EXCL_START
+  SOPHUS_INHERIT_ASSIGNMENT_OPERATORS(Map);
+  // LCOV_EXCL_STOP
 
-  // base is friend so unit_quaternion_nonconst can be accessed from base
-  friend class Sophus::SO3GroupBase<Map<Sophus::SO3Group<_Scalar>, _Options> >;
-
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(Scalar* coeffs) : unit_quaternion_(coeffs) {
-  }
+  SOPHUS_FUNC Map(Scalar* coeffs) : unit_quaternion_(coeffs) {}
 
-  /**
-   * \brief Accessor of unit quaternion
-   *
-   * No direct write access is given to ensure the quaternion stays normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstQuaternionReference unit_quaternion() const {
+  /// Accessor of unit quaternion.
+  ///
+  SOPHUS_FUNC Map<Eigen::Quaternion<Scalar>, Options> const& unit_quaternion()
+      const {
     return unit_quaternion_;
   }
 
-protected:
-  // Mutator of unit_quaternion is protected so users are hampered
-  // from setting non-unit quaternions.
-  EIGEN_STRONG_INLINE
-  QuaternionReference unit_quaternion_nonconst() {
+ protected:
+  /// Mutator of unit_quaternion is protected to ensure class invariant.
+  ///
+  SOPHUS_FUNC Map<Eigen::Quaternion<Scalar>, Options>&
+  unit_quaternion_nonconst() {
     return unit_quaternion_;
   }
 
-  Map<Quaternion<Scalar>,_Options> unit_quaternion_;
+  Map<Eigen::Quaternion<Scalar>, Options> unit_quaternion_;
 };
 
-/**
- * \brief Specialisation of Eigen::Map for const SO3GroupBase
- *
- * Allows us to wrap SO3 Objects around POD array
- * (e.g. external c style quaternion)
- */
-template<typename _Scalar, int _Options>
-class Map<const Sophus::SO3Group<_Scalar>, _Options>
-    : public Sophus::SO3GroupBase<
-    Map<const Sophus::SO3Group<_Scalar>, _Options> > {
-  typedef Sophus::SO3GroupBase<Map<const Sophus::SO3Group<_Scalar>, _Options> >
-  Base;
+/// Specialization of Eigen::Map for ``SO3 const``; derived from SO3Base.
+///
+/// Allows us to wrap SO3 objects around POD array (e.g. external c style
+/// quaternion).
+template <class Scalar_, int Options>
+class Map<Sophus::SO3<Scalar_> const, Options>
+    : public Sophus::SO3Base<Map<Sophus::SO3<Scalar_> const, Options>> {
+ public:
+  using Base = Sophus::SO3Base<Map<Sophus::SO3<Scalar_> const, Options>>;
+  using Scalar = Scalar_;
+  using Transformation = typename Base::Transformation;
+  using Point = typename Base::Point;
+  using HomogeneousPoint = typename Base::HomogeneousPoint;
+  using Tangent = typename Base::Tangent;
+  using Adjoint = typename Base::Adjoint;
 
-public:
-  /** \brief scalar type */
-  typedef typename internal::traits<Map>::Scalar Scalar;
-  /** \brief quaternion const reference type */
-  typedef const typename internal::traits<Map>::QuaternionType &
-  ConstQuaternionReference;
-
-  /** \brief degree of freedom of group */
-  static const int DoF = Base::DoF;
-  /** \brief number of internal parameters used */
-  static const int num_parameters = Base::num_parameters;
-  /** \brief group transformations are NxN matrices */
-  static const int N = Base::N;
-  /** \brief group transfomation type */
-  typedef typename Base::Transformation Transformation;
-  /** \brief point type */
-  typedef typename Base::Point Point;
-  /** \brief tangent vector type */
-  typedef typename Base::Tangent Tangent;
-  /** \brief adjoint transformation type */
-  typedef typename Base::Adjoint Adjoint;
-
-  EIGEN_INHERIT_ASSIGNMENT_EQUAL_OPERATOR(Map)
   using Base::operator*=;
   using Base::operator*;
 
-  EIGEN_STRONG_INLINE
-  Map(const Scalar* coeffs) : unit_quaternion_(coeffs) {
-  }
+  SOPHUS_FUNC Map(Scalar const* coeffs) : unit_quaternion_(coeffs) {}
 
-  /**
-   * \brief Accessor of unit quaternion
-   *
-   * No direct write access is given to ensure the quaternion stays normalized.
-   */
-  EIGEN_STRONG_INLINE
-  ConstQuaternionReference unit_quaternion() const {
+  /// Accessor of unit quaternion.
+  ///
+  SOPHUS_FUNC Map<Eigen::Quaternion<Scalar> const, Options> const&
+  unit_quaternion() const {
     return unit_quaternion_;
   }
 
-protected:
-  const Map<const Quaternion<Scalar>,_Options> unit_quaternion_;
+ protected:
+  /// Mutator of unit_quaternion is protected to ensure class invariant.
+  ///
+  Map<Eigen::Quaternion<Scalar> const, Options> const unit_quaternion_;
 };
-
-}
+}  // namespace Eigen
 
 #endif

--- a/thirdparty/sophus/test_macros.hpp
+++ b/thirdparty/sophus/test_macros.hpp
@@ -1,0 +1,129 @@
+#ifndef SOPUHS_TESTS_MACROS_HPP
+#define SOPUHS_TESTS_MACROS_HPP
+
+#include <sophus/types.hpp>
+#include <sophus/formatstring.hpp>
+
+namespace Sophus {
+namespace details {
+
+template <class Scalar>
+class Pretty {
+ public:
+  static std::string impl(Scalar s) { return FormatString("%", s); }
+};
+
+template <class Scalar, int M, int N>
+class Pretty<Eigen::Matrix<Scalar, M, N>> {
+ public:
+  static std::string impl(Matrix<Scalar, M, N> const& v) {
+    return FormatString("\n%\n", v);
+  }
+};
+
+template <class T>
+std::string pretty(T const& v) {
+  return Pretty<T>::impl(v);
+}
+
+template <class... Args>
+void testFailed(bool& passed, char const* func, char const* file, int line,
+                std::string const& msg) {
+  std::cerr << FormatString("Test failed in function %, file %, line %\n", func,
+                            file, line);
+  std::cerr << msg << "\n\n";
+  passed = false;
+}
+}  // namespace details
+
+void processTestResult(bool passed) {
+  if (!passed) {
+    // LCOV_EXCL_START
+    std::cerr << "failed!" << std::endl << std::endl;
+    exit(-1);
+    // LCOV_EXCL_STOP
+  }
+  std::cerr << "passed." << std::endl << std::endl;
+}
+}  // namespace Sophus
+
+#define SOPHUS_STRINGIFY(x) #x
+
+/// GenericTests whether condition is true.
+/// The in-out parameter passed will be set to false if test fails.
+#define SOPHUS_TEST(passed, condition, ...)                                    \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      std::string msg = Sophus::details::FormatString(                         \
+          "condition ``%`` is false\n", SOPHUS_STRINGIFY(condition));          \
+      msg += Sophus::details::FormatString(__VA_ARGS__);                       \
+      Sophus::details::testFailed(passed, SOPHUS_FUNCTION, __FILE__, __LINE__, \
+                                  msg);                                        \
+    }                                                                          \
+  } while (false)
+
+/// GenericTests whether left is equal to right given a threshold.
+/// The in-out parameter passed will be set to false if test fails.
+#define SOPHUS_TEST_EQUAL(passed, left, right, ...)                            \
+  do {                                                                         \
+    if (left != right) {                                                       \
+      std::string msg = Sophus::details::FormatString(                         \
+          "% (=%) is not equal to % (=%)\n", SOPHUS_STRINGIFY(left),           \
+          Sophus::details::pretty(left), SOPHUS_STRINGIFY(right),              \
+          Sophus::details::pretty(right));                                     \
+      msg += Sophus::details::FormatString(__VA_ARGS__);                       \
+      Sophus::details::testFailed(passed, SOPHUS_FUNCTION, __FILE__, __LINE__, \
+                                  msg);                                        \
+    }                                                                          \
+  } while (false)
+
+/// GenericTests whether left is equal to right given a threshold.
+/// The in-out parameter passed will be set to false if test fails.
+#define SOPHUS_TEST_NEQ(passed, left, right, ...)                              \
+  do {                                                                         \
+    if (left == right) {                                                       \
+      std::string msg = Sophus::details::FormatString(                         \
+          "% (=%) shoudl not be equal to % (=%)\n", SOPHUS_STRINGIFY(left),    \
+          Sophus::details::pretty(left), SOPHUS_STRINGIFY(right),              \
+          Sophus::details::pretty(right));                                     \
+      msg += Sophus::details::FormatString(__VA_ARGS__);                       \
+      Sophus::details::testFailed(passed, SOPHUS_FUNCTION, __FILE__, __LINE__, \
+                                  msg);                                        \
+    }                                                                          \
+  } while (false)
+
+/// GenericTests whether left is approximatly equal to right given a threshold.
+/// The in-out parameter passed will be set to false if test fails.
+#define SOPHUS_TEST_APPROX(passed, left, right, thr, ...)                      \
+  do {                                                                         \
+    auto nrm = Sophus::maxMetric((left), (right));                             \
+    if (!(nrm < (thr))) {                                                      \
+      std::string msg = Sophus::details::FormatString(                         \
+          "% (=%) is not approx % (=%); % is %; nrm is %\n",                   \
+          SOPHUS_STRINGIFY(left), Sophus::details::pretty(left),               \
+          SOPHUS_STRINGIFY(right), Sophus::details::pretty(right),             \
+          SOPHUS_STRINGIFY(thr), Sophus::details::pretty(thr), nrm);           \
+      msg += Sophus::details::FormatString(__VA_ARGS__);                       \
+      Sophus::details::testFailed(passed, SOPHUS_FUNCTION, __FILE__, __LINE__, \
+                                  msg);                                        \
+    }                                                                          \
+  } while (false)
+
+/// GenericTests whether left is NOT approximatly equal to right given a
+/// threshold. The in-out parameter passed will be set to false if test fails.
+#define SOPHUS_TEST_NOT_APPROX(passed, left, right, thr, ...)                  \
+  do {                                                                         \
+    auto nrm = Sophus::maxMetric((left), (right));                             \
+    if (nrm < (thr)) {                                                         \
+      std::string msg = Sophus::details::FormatString(                         \
+          "% (=%) is approx % (=%), but it should not!\n % is %; nrm is %\n",  \
+          SOPHUS_STRINGIFY(left), Sophus::details::pretty(left),               \
+          SOPHUS_STRINGIFY(right), Sophus::details::pretty(right),             \
+          SOPHUS_STRINGIFY(thr), Sophus::details::pretty(thr), nrm);           \
+      msg += Sophus::details::FormatString(__VA_ARGS__);                       \
+      Sophus::details::testFailed(passed, SOPHUS_FUNCTION, __FILE__, __LINE__, \
+                                  msg);                                        \
+    }                                                                          \
+  } while (false)
+
+#endif  // SOPUHS_TESTS_MACROS_HPP

--- a/thirdparty/sophus/types.hpp
+++ b/thirdparty/sophus/types.hpp
@@ -1,0 +1,241 @@
+/// @file
+/// Common type aliases.
+
+#ifndef SOPHUS_TYPES_HPP
+#define SOPHUS_TYPES_HPP
+
+#include <type_traits>
+#include "common.hpp"
+
+namespace Sophus {
+
+template <class Scalar, int M, int Options = 0>
+using Vector = Eigen::Matrix<Scalar, M, 1, Options>;
+
+template <class Scalar, int Options = 0>
+using Vector2 = Vector<Scalar, 2, Options>;
+using Vector2f = Vector2<float>;
+using Vector2d = Vector2<double>;
+
+template <class Scalar, int Options = 0>
+using Vector3 = Vector<Scalar, 3, Options>;
+using Vector3f = Vector3<float>;
+using Vector3d = Vector3<double>;
+
+template <class Scalar>
+using Vector4 = Vector<Scalar, 4>;
+using Vector4f = Vector4<float>;
+using Vector4d = Vector4<double>;
+
+template <class Scalar>
+using Vector6 = Vector<Scalar, 6>;
+using Vector6f = Vector6<float>;
+using Vector6d = Vector6<double>;
+
+template <class Scalar>
+using Vector7 = Vector<Scalar, 7>;
+using Vector7f = Vector7<float>;
+using Vector7d = Vector7<double>;
+
+template <class Scalar, int M, int N>
+using Matrix = Eigen::Matrix<Scalar, M, N>;
+
+template <class Scalar>
+using Matrix2 = Matrix<Scalar, 2, 2>;
+using Matrix2f = Matrix2<float>;
+using Matrix2d = Matrix2<double>;
+
+template <class Scalar>
+using Matrix3 = Matrix<Scalar, 3, 3>;
+using Matrix3f = Matrix3<float>;
+using Matrix3d = Matrix3<double>;
+
+template <class Scalar>
+using Matrix4 = Matrix<Scalar, 4, 4>;
+using Matrix4f = Matrix4<float>;
+using Matrix4d = Matrix4<double>;
+
+template <class Scalar>
+using Matrix6 = Matrix<Scalar, 6, 6>;
+using Matrix6f = Matrix6<float>;
+using Matrix6d = Matrix6<double>;
+
+template <class Scalar>
+using Matrix7 = Matrix<Scalar, 7, 7>;
+using Matrix7f = Matrix7<float>;
+using Matrix7d = Matrix7<double>;
+
+template <class Scalar, int N, int Options = 0>
+using ParametrizedLine = Eigen::ParametrizedLine<Scalar, N, Options>;
+
+template <class Scalar, int Options = 0>
+using ParametrizedLine3 = ParametrizedLine<Scalar, 3, Options>;
+using ParametrizedLine3f = ParametrizedLine3<float>;
+using ParametrizedLine3d = ParametrizedLine3<double>;
+
+template <class Scalar, int Options = 0>
+using ParametrizedLine2 = ParametrizedLine<Scalar, 2, Options>;
+using ParametrizedLine2f = ParametrizedLine2<float>;
+using ParametrizedLine2d = ParametrizedLine2<double>;
+
+namespace details {
+template <class Scalar>
+class MaxMetric {
+ public:
+  static Scalar impl(Scalar s0, Scalar s1) {
+    using std::abs;
+    return abs(s0 - s1);
+  }
+};
+
+template <class Scalar, int M, int N>
+class MaxMetric<Matrix<Scalar, M, N>> {
+ public:
+  static Scalar impl(Matrix<Scalar, M, N> const& p0,
+                     Matrix<Scalar, M, N> const& p1) {
+    return (p0 - p1).template lpNorm<Eigen::Infinity>();
+  }
+};
+
+template <class Scalar>
+class SetToZero {
+ public:
+  static void impl(Scalar& s) { s = Scalar(0); }
+};
+
+template <class Scalar, int M, int N>
+class SetToZero<Matrix<Scalar, M, N>> {
+ public:
+  static void impl(Matrix<Scalar, M, N>& v) { v.setZero(); }
+};
+
+template <class T1, class Scalar>
+class SetElementAt;
+
+template <class Scalar>
+class SetElementAt<Scalar, Scalar> {
+ public:
+  static void impl(Scalar& s, Scalar value, int at) {
+    SOPHUS_ENSURE(at == 0, "is %", at);
+    s = value;
+  }
+};
+
+template <class Scalar, int N>
+class SetElementAt<Vector<Scalar, N>, Scalar> {
+ public:
+  static void impl(Vector<Scalar, N>& v, Scalar value, int at) {
+    SOPHUS_ENSURE(at >= 0 && at < N, "is %", at);
+    v[at] = value;
+  }
+};
+
+template <class Scalar>
+class SquaredNorm {
+ public:
+  static Scalar impl(Scalar const& s) { return s * s; }
+};
+
+template <class Scalar, int N>
+class SquaredNorm<Matrix<Scalar, N, 1>> {
+ public:
+  static Scalar impl(Matrix<Scalar, N, 1> const& s) { return s.squaredNorm(); }
+};
+
+template <class Scalar>
+class Transpose {
+ public:
+  static Scalar impl(Scalar const& s) { return s; }
+};
+
+template <class Scalar, int M, int N>
+class Transpose<Matrix<Scalar, M, N>> {
+ public:
+  static Matrix<Scalar, M, N> impl(Matrix<Scalar, M, N> const& s) {
+    return s.transpose();
+  }
+};
+}  // namespace details
+
+/// Returns maximum metric between two points ``p0`` and ``p1``, with ``p0, p1``
+/// being matrices or a scalars.
+///
+template <class T>
+auto maxMetric(T const& p0, T const& p1)
+    -> decltype(details::MaxMetric<T>::impl(p0, p1)) {
+  return details::MaxMetric<T>::impl(p0, p1);
+}
+
+/// Sets point ``p`` to zero, with ``p`` being a matrix or a scalar.
+///
+template <class T>
+void setToZero(T& p) {
+  return details::SetToZero<T>::impl(p);
+}
+
+/// Sets ``i``th component of ``p`` to ``value``, with ``p`` being a
+/// matrix or a scalar. If ``p`` is a scalar, ``i`` must be ``0``.
+///
+template <class T, class Scalar>
+void setElementAt(T& p, Scalar value, int i) {
+  return details::SetElementAt<T, Scalar>::impl(p, value, i);
+}
+
+/// Returns the squared 2-norm of ``p``, with ``p`` being a vector or a scalar.
+///
+template <class T>
+auto squaredNorm(T const& p) -> decltype(details::SquaredNorm<T>::impl(p)) {
+  return details::SquaredNorm<T>::impl(p);
+}
+
+/// Returns ``p.transpose()`` if ``p`` is a matrix, and simply ``p`` if m is a
+/// scalar.
+///
+template <class T>
+auto transpose(T const& p) -> decltype(details::Transpose<T>::impl(T())) {
+  return details::Transpose<T>::impl(p);
+}
+
+template <class Scalar>
+struct IsFloatingPoint {
+  static bool const value = std::is_floating_point<Scalar>::value;
+};
+
+template <class Scalar, int M, int N>
+struct IsFloatingPoint<Matrix<Scalar, M, N>> {
+  static bool const value = std::is_floating_point<Scalar>::value;
+};
+
+template <class Scalar_>
+struct GetScalar {
+  using Scalar = Scalar_;
+};
+
+template <class Scalar_, int M, int N>
+struct GetScalar<Matrix<Scalar_, M, N>> {
+  using Scalar = Scalar_;
+};
+
+/// If the Vector type is of fixed size, then IsFixedSizeVector::value will be
+/// true.
+template <typename Vector, int NumDimensions,
+          typename = typename std::enable_if<
+              Vector::RowsAtCompileTime == NumDimensions &&
+              Vector::ColsAtCompileTime == 1>::type>
+struct IsFixedSizeVector : std::true_type {};
+
+/// Planes in 3d are hyperplanes.
+template <class T>
+using Plane3 = Eigen::Hyperplane<T, 3>;
+using Plane3d = Plane3<double>;
+using Plane3f = Plane3<float>;
+
+/// Lines in 2d are hyperplanes.
+template <class T>
+using Line2 = Eigen::Hyperplane<T, 2>;
+using Line2d = Line2<double>;
+using Line2f = Line2<float>;
+
+}  // namespace Sophus
+
+#endif  // SOPHUS_TYPES_HPP

--- a/thirdparty/sophus/velocities.hpp
+++ b/thirdparty/sophus/velocities.hpp
@@ -1,0 +1,74 @@
+#ifndef SOPHUS_VELOCITIES_HPP
+#define SOPHUS_VELOCITIES_HPP
+
+#include <functional>
+
+#include "num_diff.hpp"
+#include "se3.hpp"
+
+namespace Sophus {
+namespace experimental {
+// Experimental since the API will certainly change drastically in the future.
+
+// Transforms velocity vector by rotation ``foo_R_bar``.
+//
+// Note: vel_bar can be either a linear or a rotational velocity vector.
+//
+template <class Scalar>
+Vector3<Scalar> transformVelocity(SO3<Scalar> const& foo_R_bar,
+                                  Vector3<Scalar> const& vel_bar) {
+  // For rotational velocities note that:
+  //
+  //   vel_bar = vee(foo_R_bar * hat(vel_bar) * foo_R_bar^T)
+  //           = vee(hat(Adj(foo_R_bar) * vel_bar))
+  //           = Adj(foo_R_bar) * vel_bar
+  //           = foo_R_bar * vel_bar.
+  //
+  return foo_R_bar * vel_bar;
+}
+
+// Transforms velocity vector by pose ``foo_T_bar``.
+//
+// Note: vel_bar can be either a linear or a rotational velocity vector.
+//
+template <class Scalar>
+Vector3<Scalar> transformVelocity(SE3<Scalar> const& foo_T_bar,
+                                  Vector3<Scalar> const& vel_bar) {
+  return transformVelocity(foo_T_bar.so3(), vel_bar);
+}
+
+// finite difference approximation of instantanious velocity in frame foo
+//
+template <class Scalar>
+Vector3<Scalar> finiteDifferenceRotationalVelocity(
+    std::function<SO3<Scalar>(Scalar)> const& foo_R_bar, Scalar t,
+    Scalar h = Constants<Scalar>::epsilon()) {
+  // https://en.wikipedia.org/w/index.php?title=Angular_velocity&oldid=791867792#Angular_velocity_tensor
+  //
+  // W = dR(t)/dt * R^{-1}(t)
+  Matrix3<Scalar> dR_dt_in_frame_foo = curveNumDiff(
+      [&foo_R_bar](Scalar t0) -> Matrix3<Scalar> {
+        return foo_R_bar(t0).matrix();
+      },
+      t, h);
+  // velocity tensor
+  Matrix3<Scalar> W_in_frame_foo =
+      dR_dt_in_frame_foo * (foo_R_bar(t)).inverse().matrix();
+  return SO3<Scalar>::vee(W_in_frame_foo);
+}
+
+// finite difference approximation of instantanious velocity in frame foo
+//
+template <class Scalar>
+Vector3<Scalar> finiteDifferenceRotationalVelocity(
+    std::function<SE3<Scalar>(Scalar)> const& foo_T_bar, Scalar t,
+    Scalar h = Constants<Scalar>::epsilon()) {
+  return finiteDifferenceRotationalVelocity<Scalar>(
+      [&foo_T_bar](Scalar t) -> SO3<Scalar> { return foo_T_bar(t).so3(); }, t,
+      h);
+}
+
+}  // namespace experimental
+}  // namespace Sophus
+
+#endif  // SOPHUS_VELOCITIES_HPP


### PR DESCRIPTION
Hello, it's me again :smile: 

Here is a big PR which i have been working for a long time, I tried to decompose the important steps in meaningfull commit, although I haven't checked the build between each commit

The main point of this branch is to be able to work on big datasets with any images, and to work with point clouds that are more noisy and less dense than faro. I ensured that functionality regarding ETH3D initial dataset was not altered. I also changed the 

As such here are the features that I added to improve speed :
 -  Add Multithreading with openmp wherever possible : GroudtruthCreator, SplatCreator, and for occlusion boundaries
 - Prevent the program to filter out occlusion boundaries for splats : by onstruction they don't have any, so now the occlusion splats are a different parameter than occlusion mesh (i adapted the README accordingly)
 - Make the problem object only load images if necessary. For videos, you may have a memory error because of that. GroundtruthCreator is currently the only tool where there is a change. The rationale behind it is that you can run the image registrator with a small subset of the video frames, and interpolate the deformation after that only to create ground truth on the whole video.

Here are the features to deal with low quality occlusion meshes :
 - Occlusion boundaries does not assume the mesh to be on a perfect manifold. This is particuarly true for mesh constructed with unordered point clouds : Poisson Meshing is not possible anymore, and you might use PCL's greedy projection. As such, the code is robust to mesh edges with more than two faces. Besides, it automatically filters out very flat edges which have a very low chances of actually be an occlusion boundary.
- The code now accepts meshlab projects as well as simple ply. This is interesting if you need to finetune the point cloud registration with respect to the colmap model, the same way as the lidar scans.
- 2D splats size are no longer a fixed size in pixels. Instead, a value in meters is given for splat radius and the 2D splat is the same size as if it was a 3D object of size splat radius oriented toward the camera. This is interesting for noisy meshes with many occlusion boundaries, where if far enough, would be considered only occlusion boundaries, and thus hide all possible GT points

Here are the remaining feature added :
 - Some log info for Ground truth Creator and Splat Creator
 - I changed the range of possible cloud transformations, and added scale to SO3, hence Sim3. This does not affect ICPScanAligner (although it would be nice) nor ImageRegistrator, where everything is kept SO3. The only diffrence is when there is scale information in the matrix given in the meshlab project. Note that for that, I had to update Sophus.
 - I added max occlusion depth options, I personally dealed with a 200m wide models, so I had to change it
 - Depth Maps and Occlusion Depth Maps can now be compressed on the fly before being saved in GroundTruthCreator
 - You can now launch DatasetInspector without multiscale pointcloud just to check depth maps. (it will warn you though)

Thanks for your help and for accepting my former PR.
I have been using your code for my own research on groundtruth depth for videos, I hope I will be able to share it with you soon, using your code was very instructive !

Best, Clément